### PR TITLE
Measured version 0.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,14 @@
+/.bundle/
+/.yardoc
+/Gemfile.lock
+/_yardoc/
+/coverage/
+/doc/
+/pkg/
+/spec/reports/
+/tmp/
+*.bundle
+*.so
+*.o
+*.a
+mkmf.log

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Kevin McPhillips
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,0 +1,208 @@
+# Measured
+
+Encapsulates measruements with their units. Provides easy conversion between units.
+
+Light weight and easily extensible to include other units and conversions. Conversions done with `BigDecimal` for precision.
+
+## Installation
+
+Using bundler, add to the Gemfile:
+
+```ruby
+gem 'measured'
+```
+
+Or stand alone:
+
+    $ gem install measured
+
+## Usage
+
+Initialize a measurement:
+
+```ruby
+Measured::Weight.new("12", "g")
+```
+
+Convert to return a new measurement:
+
+```ruby
+Measured::Weight.new("12", "g").convert_to("kg")
+```
+
+Or convert inline:
+
+```ruby
+Measured::Weight.new("12", "g").convert_to!("kg")
+```
+
+Agnostic to symbols/strings:
+
+```ruby
+Measured::Weight.new(1, "kg") == Measured::Weight.new(1, :kg)
+```
+
+Seamlessly handles aliases:
+
+```ruby
+Measured::Weight.new(12, :oz) == Measured::Weight.new("12", :ounce)
+```
+
+Raises on unknown units:
+
+```ruby
+begin
+  Measured::Weight.new(1, :stone)
+rescue Measured::UnitError
+  puts "Unknown unit"
+end
+```
+
+Perform mathematical operations against other units, all represented internally as `BigDecimal`:
+
+```ruby
+Measured::Weight.new(1, :g) + Measured::Weight.new(2, :g)
+> #<Measured::Weight 3 g>
+Measured::Weight.new(2, :g) - Measured::Weight.new(1, :g)
+> #<Measured::Weight 1 g>
+Measured::Weight.new(10, :g) / Measured::Weight.new(2, :g)
+> #<Measured::Weight 5 g>
+Measured::Weight.new(2, :g) * Measured::Weight.new(3, :g)
+> #<Measured::Weight 6 g>
+```
+
+In cases of differing units, the left hand side takes precedence:
+
+```ruby
+Measured::Weight.new(1000, :g) + Measured::Weight.new(1, :kg)
+> #<Measured::Weight 2000 g>
+```
+
+Also perform mathematical operations against `Numeric` things:
+
+```ruby
+Measured::Weight.new(3, :g) * 2
+> #<Measured::Weight 6 g>
+```
+
+Extract the unit and the value:
+
+```ruby
+weight = Measured::Weight.new("1.2", "grams")
+weight.value
+> #<BigDecimal 1.2>
+weight.unit
+> "g"
+```
+
+See all valid units:
+
+```ruby
+Measured::Weight.units
+> ["g", "kg", "lb", "oz"]
+```
+
+See all valid units with their aliases:
+
+```ruby
+Measured::Weight.units_with_aliases
+> ["g", "gram", "grams", "kg", "kilogram", "kilograms", "lb", "lbs", "ounce", "ounces", "oz", "pound", "pounds"]
+```
+
+## Units and conversions
+
+### Bundled unit conversion
+
+* `Measured::Weight`
+  * g, gram, grams
+  * kg, kilogram, kilograms
+  * lb, lbs, pound, pounds
+  * oz, ounce, ounces
+* `Measured::Length`
+  * m, meter, metre, meters, metres
+  * cm, centimeter, centimetre, centimeters, centimetres
+  * mm, millimeter, millimetre, millimeters, millimetres
+  * in, inch, inches
+  * ft, foot, feet
+  * yd, yard, yards
+
+You can skip these and only define your own units by doing:
+
+```ruby
+gem 'measured', require: 'measured/base'
+```
+
+### Adding new units
+
+Extending this library to support other units is simple. To add a new conversion, subclass `Measured::Measurable`, define your base units, then add your conversion units.
+
+```ruby
+class Measured::Thing < Measured::Measurable
+  conversion.set_base :base_unit,           # Define the basic unit for the system
+    aliases: [:bu]                          # Allow it to be aliased to other names/symbols
+
+  conversion.add :another_unit,             # Add a second unit to the system
+    aliases: [:au],                         # All units allow aliases, as long as they are unique
+    value: ["1.5 base_unit"]                # The conversion rate to another unit
+
+  conversion.add :different_unit
+    aliases: [:du],
+    value: [Rational(2/3), "another_unit"]  # Conversion rate can be Rational, otherwise it is coerced to BigDecimal
+end
+```
+
+The base unit takes no value. Values for conversion units can be defined as a string with two tokens `"number unit"` or as an array with two elements. The numbers must be `Rational` or `BigDecimal`, else they will be coerced to `BigDecimal`. Conversion paths don't have to be direct as a conversion table will be built for all possible conversions using tree traversal.
+
+You can also open up the existing classes and add a new conversion:
+
+```ruby
+class Measured::Length
+  conversion.add :dm,
+    aliases: [:decimeter, :decimetre, :decimeters, :decimetres],
+    value: "0.1 m"
+end
+```
+
+### Namespaces
+
+All units and classes are namespaced by default, but can be aliased in your application.
+
+```ruby
+Weight = Measured::Weight
+Length = Measured::Length
+```
+
+## Alternatives
+
+Existing alternatives which were considered:
+
+### Gem: [ruby-units](https://github.com/olbrich/ruby-units)
+* **Pros**
+  * Accurate math and conversion factors.
+  * Includes nearly every unit you could ask for.
+* **Cons**
+  * Opens up and modifies `Array`, `Date`, `Fixnum`, `Math`, `Numeric`, `String`, `Time`, and `Object`, then depends on those changes internally.
+  * Lots of code to solve a relatively simple problem.
+  * No ActiveRecord adapter.
+
+### Gem: [quantified](https://github.com/Shopify/quantified)
+* **Pros**
+  * Light weight.
+  * Included with ActiveShipping/ActiveUtils.
+* **Cons**
+  * All math done with floats making it highly lossy.
+  * All units assumed to be pluralized, meaning using unit abbreviations is not possible.
+  * Not actively maintained.
+  * No ActiveRecord adapter.
+
+## Contributing
+
+1. Fork it ( https://github.com/Shopify/measured/fork )
+2. Create your feature branch (`git checkout -b my-new-feature`)
+3. Commit your changes (`git commit -am 'Add some feature'`)
+4. Push to the branch (`git push origin my-new-feature`)
+5. Create a new Pull Request
+
+## Authors
+
+* [Kevin McPhillips](https://github.com/kmcphillips) at [Shopify](http://shopify.com/careers)

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,21 @@
+require "bundler/gem_tasks"
+require 'rake/testtask'
+
+$LOAD_PATH.unshift File.expand_path("../lib", __FILE__)
+require "measured/version"
+
+task default: :test
+
+desc 'Run the test stuite'
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.libs << "lib/**/*"
+  t.test_files = FileList['test/**/*_test.rb']
+  t.verbose = true
+end
+
+task tag: :build do
+  system "git commit -m'Released version #{ Measured::VERSION }' --allow-empty"
+  system "git tag -a v#{ Measured::VERSION } -m 'Tagging #{ Measured::VERSION }'"
+  system "git push --tags"
+end

--- a/lib/measured.rb
+++ b/lib/measured.rb
@@ -1,3 +1,4 @@
 require "measured/base"
 
 require "measured/units/length"
+require "measured/units/weight"

--- a/lib/measured.rb
+++ b/lib/measured.rb
@@ -1,1 +1,3 @@
 require "measured/base"
+
+require "measured/units/length"

--- a/lib/measured.rb
+++ b/lib/measured.rb
@@ -1,0 +1,1 @@
+require "measured/base"

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -1,0 +1,37 @@
+module Measured::Arithmetic
+  def +(other)
+    arithmetic_operation(other, :+)
+  end
+
+  def -(other)
+    arithmetic_operation(other, :-)
+  end
+
+  def *(other)
+    arithmetic_operation(other, :*)
+  end
+
+  def /(other)
+    arithmetic_operation(other, :/)
+  end
+
+  def -@
+    self.class.new(-self.value, self.unit)
+  end
+
+  def coerce(other)
+    [self, other]
+  end
+
+  private
+
+  def arithmetic_operation(other, operator)
+    if other.is_a?(self.class)
+      self.class.new(self.value.send(operator, other.convert_to(self.unit).value), self.unit)
+    elsif other.is_a?(Numeric)
+      self.class.new(self.value.send(operator, other), self.unit)
+    else
+      raise TypeError, "Invalid operation #{ operator } between #{ self.class } to #{ other.class }"
+    end
+  end
+end

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -1,0 +1,13 @@
+require "measured/version"
+require "active_support"
+require "bigdecimal"
+
+module Measured
+  class UnitError < StandardError ; end
+end
+
+require "measured/arithmetic"
+require "measured/unit"
+require "measured/conversion"
+require "measured/conversion_table"
+require "measured/measurable"

--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -1,0 +1,91 @@
+class Measured::Conversion
+  def initialize
+    @base_unit = nil
+    @units = []
+  end
+
+  attr_reader :base_unit, :units
+
+  def set_base(unit_name, aliases: [])
+    add_new_unit(unit_name, aliases: aliases, base: true)
+  end
+
+  def add(unit_name, aliases: [], value:)
+    add_new_unit(unit_name, aliases: aliases, value: value)
+  end
+
+  def unit_names_with_aliases
+    @units.map{|u| u.names}.flatten.sort
+  end
+
+  def unit_names
+    @units.map{|u| u.name}.sort
+  end
+
+  def unit_or_alias?(name)
+    unit_names_with_aliases.include?(name.to_s)
+  end
+
+  def unit?(name)
+    unit_names.include?(name.to_s)
+  end
+
+  def to_unit_name(name)
+    unit_for(name).name
+  end
+
+  def convert(value, from:, to:)
+    raise Measured::UnitError, "Source unit #{ from } does not exits." unless unit?(from)
+    raise Measured::UnitError, "Converted unit #{ to } does not exits." unless unit?(to)
+
+    from_unit = unit_for(from)
+    to_unit = unit_for(to)
+
+    raise Measured::UnitError, "Cannot find conversion entry from #{ from } to #{ to }" unless conversion = conversion_table[from][to]
+
+    value * conversion
+  end
+
+  def conversion_table
+    @conversion_table ||= Measured::ConversionTable.new(@units).to_h
+  end
+
+  private
+
+  def add_new_unit(unit_name, aliases:, value: nil, base: false)
+    if base && @base_unit
+      raise Measured::UnitError, "Can only have one base unit. Adding #{ unit_name } but already defined #{ @base_unit }."
+    elsif !base && !@base_unit
+      raise Measured::UnitError, "A base unit has not yet been set."
+    end
+
+    check_for_duplicate_unit_names([unit_name] + aliases)
+
+    unit = Measured::Unit.new(unit_name, aliases: aliases, value: value)
+    @units << unit
+    @base_unit = unit if base
+
+    clear_conversion_table
+
+    unit
+  end
+
+  def check_for_duplicate_unit_names(names)
+    names.each do |name|
+      raise Measured::UnitError, "Unit #{ name } has already been added." if unit_or_alias?(name)
+    end
+  end
+
+  def unit_for(name)
+    @units.each do |unit|
+      return unit if unit.names.include?(name.to_s)
+    end
+
+    raise Measured::UnitError, "Cannot find unit for #{ name }."
+  end
+
+  def clear_conversion_table
+    @conversion_table = nil
+  end
+
+end

--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -1,0 +1,67 @@
+class Measured::ConversionTable
+
+  def initialize(units)
+    @units = units
+  end
+
+  def to_h
+    table = {}
+
+    @units.map{|u| u.name}.each do |to_unit|
+      to_table = {to_unit => BigDecimal("1")}
+
+      table.each do |from_unit, from_table|
+        to_table[from_unit] = find_conversion(to: from_unit, from: to_unit)
+        from_table[to_unit] = find_conversion(to: to_unit, from: from_unit)
+      end
+
+      table[to_unit] = to_table
+    end
+
+    table
+  end
+
+  private
+
+  def find_conversion(to:, from:)
+    conversion = find_direct_conversion(to: to, from: from) || find_tree_traversal_conversion(to: to, from: from)
+
+    raise Measured::UnitError, "Cannot find conversion path from #{ from } to #{ to }." unless conversion
+
+    conversion
+  end
+
+  def find_direct_conversion(to:, from:)
+    @units.each do |unit|
+      return unit.conversion_amount if unit.name == from && unit.conversion_unit == to
+    end
+
+    @units.each do |unit|
+      return unit.inverse_conversion_amount if unit.name == to && unit.conversion_unit == from
+    end
+
+    nil
+  end
+
+  def find_tree_traversal_conversion(to:, from:)
+    traverse(from: from, to: to, unit_names: @units.map{|u| u.name }, amount: BigDecimal("1"))
+  end
+
+  def traverse(from:, to:, unit_names:, amount:)
+    unit_names = unit_names - [from]
+
+    unit_names.each do |name|
+      if conversion = find_direct_conversion(from: from, to: name)
+        if name == to
+          return amount * conversion
+        else
+          result = traverse(from: name, to: to, unit_names: unit_names, amount: amount * conversion)
+          return result if result
+        end
+      end
+    end
+
+    nil
+  end
+
+end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -1,0 +1,67 @@
+class Measured::Measurable
+  include Comparable
+  include Measured::Arithmetic
+
+  attr_reader :unit, :value
+
+  def initialize(value, unit)
+    raise Measured::UnitError, "Unit #{ unit } does not exits." unless self.class.conversion.unit_or_alias?(unit)
+
+    @value = value
+    @value = BigDecimal(@value) unless @value.is_a?(BigDecimal)
+
+    @unit = self.class.conversion.to_unit_name(unit)
+  end
+
+  def convert_to(new_unit)
+    new_unit_name = self.class.conversion.to_unit_name(new_unit)
+    value = self.class.conversion.convert(@value, from: @unit, to: new_unit_name)
+
+    self.class.new(value, new_unit)
+  end
+
+  def convert_to!(new_unit)
+    converted = convert_to(new_unit)
+
+    @value = converted.value
+    @unit = converted.unit
+
+    self
+  end
+
+  def to_s
+    [value.to_f.to_s.gsub(/\.0\Z/, ""), unit].join(" ")
+  end
+
+  def inspect
+    "#<#{ self.class }: #{ value } #{ unit }>"
+  end
+
+  def <=>(other)
+    if other.is_a?(self.class) && unit == other.unit
+      value <=> other.value
+    end
+  end
+
+  def ==(other)
+    !!(other.is_a?(self.class) && unit == other.unit && value == other.value)
+  end
+
+  alias_method :eql?, :==
+
+  class << self
+
+    def conversion
+      @conversion ||= Measured::Conversion.new
+    end
+
+    def units
+      conversion.unit_names
+    end
+
+    def units_with_aliases
+      conversion.unit_names_with_aliases
+    end
+
+  end
+end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -1,0 +1,59 @@
+class Measured::Unit
+  include Comparable
+
+  def initialize(name, aliases: [], value: nil)
+    @name = name.to_s
+    @names = ([@name] + aliases.map{|n| n.to_s }).sort
+
+    @conversion_amount, @conversion_unit = parse_value(value) if value
+  end
+
+  attr_reader :name, :names, :conversion_amount, :conversion_unit
+
+  def to_s
+    if conversion_string
+      "#{ @name } (#{ conversion_string })"
+    else
+      @name
+    end
+  end
+
+  def inspect
+    "#<Measured::Unit: #{ @name } (#{ @names.join(", ") }) #{ conversion_string }>"
+  end
+
+  def <=>(other)
+    if self.class == other.class
+      if other.names != @names
+        other.names <=> @names
+      else
+        other.conversion_amount <=> @conversion_amount
+      end
+    else
+      @name <=> other
+    end
+  end
+
+  def inverse_conversion_amount
+    if conversion_amount.is_a?(Rational)
+      Rational(conversion_amount.denominator, conversion_amount.numerator)
+    else
+      BigDecimal(1) /  conversion_amount
+    end
+  end
+
+  private
+
+  def conversion_string
+    "#{ conversion_amount } #{ conversion_unit }" if @conversion_amount || @conversion_unit
+  end
+
+  def parse_value(tokens)
+    tokens = tokens.split(" ") if tokens.is_a?(String)
+    raise Measured::UnitError, "Cannot parse 'number unit' or [number, unit] formatted tokens from #{ tokens }." unless tokens.size == 2
+
+    tokens[0] = BigDecimal(tokens[0]) unless tokens[0].is_a?(BigDecimal) || tokens[0].is_a?(Rational)
+
+    tokens
+  end
+end

--- a/lib/measured/units/length.rb
+++ b/lib/measured/units/length.rb
@@ -1,0 +1,26 @@
+class Measured::Length < Measured::Measurable
+
+  conversion.set_base :m,
+    aliases: [:meter, :metre, :meters, :metres]
+
+  conversion.add :cm,
+    aliases: [:centimeter, :centimetre, :centimeters, :centimetres],
+    value: "0.01 m"
+
+  conversion.add :mm,
+    aliases: [:millimeter, :millimetre, :millimeters, :millimetres],
+    value: "0.001 m"
+
+  conversion.add :in,
+    aliases: [:inch, :inches],
+    value: "0.0254 m"
+
+  conversion.add :ft,
+    aliases: [:foot, :feet],
+    value: "0.3048 m"
+
+  conversion.add :yd,
+    aliases: [:yard, :yards],
+    value: "0.9144 m"
+
+end

--- a/lib/measured/units/weight.rb
+++ b/lib/measured/units/weight.rb
@@ -1,0 +1,18 @@
+class Measured::Weight < Measured::Measurable
+
+  conversion.set_base :g,
+    aliases: [:gram, :grams]
+
+  conversion.add :kg,
+    aliases: [:kilogram, :kilograms],
+    value: "1000 g"
+
+  conversion.add :lb,
+    aliases: [:lbs, :pound, :pounds],
+    value: [Rational(45359237,1e8), "kg"]
+
+  conversion.add :oz,
+    aliases: [:ounce, :ounces],
+    value: [Rational(1,16), "lb"]
+
+end

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,0 +1,3 @@
+module Measured
+  VERSION = "0.0.1"
+end

--- a/measured.gemspec
+++ b/measured.gemspec
@@ -1,0 +1,28 @@
+# coding: utf-8
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+require 'measured/version'
+
+Gem::Specification.new do |spec|
+  spec.name          = "measured"
+  spec.version       = Measured::VERSION
+  spec.authors       = ["Kevin McPhillips"]
+  spec.email         = ["github@kevinmcphillips.ca"]
+  spec.summary       = %q{Encapsulate measurements with their units in Ruby}
+  spec.description   = %q{Wrapper objects which encapsulate measurments and their associated units in Ruby.}
+  spec.homepage      = ""
+  spec.license       = "MIT"
+
+  spec.files         = `git ls-files -z`.split("\x0")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
+  spec.require_paths = ["lib"]
+
+  spec.add_runtime_dependency "activesupport", ">= 4.0"
+
+  spec.add_development_dependency "bundler", "~> 1.7"
+  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "minitest", "~> 5.5.1"
+  spec.add_development_dependency "mocha", "~> 1.1.0"
+  spec.add_development_dependency "pry"
+end

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -1,0 +1,133 @@
+require "test_helper"
+
+class Measured::ArithmeticTest < ActiveSupport::TestCase
+  setup do
+    @two = Magic.new(2, :magic_missile)
+    @three = Magic.new(3, :magic_missile)
+    @four = Magic.new(4, :magic_missile)
+  end
+
+  test "#+ should add together same units" do
+    assert_equal Magic.new(5, :magic_missile), @two + @three
+    assert_equal Magic.new(5, :magic_missile), @three + @two
+  end
+
+  test "#+ should add a number to the value" do
+    assert_equal Magic.new(5, :magic_missile), @two + 3
+    assert_equal Magic.new(5, :magic_missile), 2 + @three
+  end
+
+  test "#+ should raise if different unit system" do
+    assert_raises TypeError do
+      OtherFakeSystem.new(1, :other_fake_base) + @two
+    end
+
+    assert_raises TypeError do
+      @two + OtherFakeSystem.new(1, :other_fake_base)
+    end
+  end
+
+  test "#+ should raise if adding something nonsense" do
+    assert_raises TypeError do
+      @two + "thing"
+    end
+
+    assert_raises TypeError do
+      "thing" + @two
+    end
+  end
+
+  test "#- should subtract same units" do
+    assert_equal Magic.new(-1, :magic_missile), @two - @three
+    assert_equal Magic.new(1, :magic_missile), @three - @two
+  end
+
+  test "#- should subtract a number from the value" do
+    assert_equal Magic.new(-1, :magic_missile), @two - 3
+    assert_equal Magic.new(1, :magic_missile), 2 - @three
+  end
+
+  test "#- should raise if different unit system" do
+    assert_raises TypeError do
+      OtherFakeSystem.new(1, :other_fake_base) - @two
+    end
+
+    assert_raises TypeError do
+      @two - OtherFakeSystem.new(1, :other_fake_base)
+    end
+  end
+
+  test "#- should raise if subtracting something nonsense" do
+    assert_raises TypeError do
+      @two - "thing"
+    end
+
+    assert_raises NoMethodError do
+      "thing" - @two
+    end
+  end
+
+  test "#* should multiply together same units" do
+    assert_equal Magic.new(6, :magic_missile), @two * @three
+    assert_equal Magic.new(6, :magic_missile), @three * @two
+  end
+
+  test "#* should multiply a number to the value" do
+    assert_equal Magic.new(6, :magic_missile), @two * 3
+    assert_equal Magic.new(6, :magic_missile), 2 * @three
+  end
+
+  test "#* should raise if different unit system" do
+    assert_raises TypeError do
+      OtherFakeSystem.new(1, :other_fake_base) * @two
+    end
+
+    assert_raises TypeError do
+      @two * OtherFakeSystem.new(1, :other_fake_base)
+    end
+  end
+
+  test "#* should raise if multiplying something nonsense" do
+    assert_raises TypeError do
+      @two * "thing"
+    end
+
+    assert_raises TypeError do
+      "thing" * @two
+    end
+  end
+
+  test "#/ should divide together same units" do
+    assert_equal Magic.new("0.5", :magic_missile), @two / @four
+    assert_equal Magic.new(2, :magic_missile), @four / @two
+  end
+
+  test "#/ should divide a number to the value" do
+    assert_equal Magic.new("0.5", :magic_missile), @two / 4
+    assert_equal Magic.new(2, :magic_missile), 2 / @four
+  end
+
+  test "#/ should raise if different unit system" do
+    assert_raises TypeError do
+      OtherFakeSystem.new(1, :other_fake_base) / @two
+    end
+
+    assert_raises TypeError do
+      @two / OtherFakeSystem.new(1, :other_fake_base)
+    end
+  end
+
+  test "#/ should raise if dividing something nonsense" do
+    assert_raises TypeError do
+      @two / "thing"
+    end
+
+    assert_raises NoMethodError do
+      "thing" / @two
+    end
+  end
+
+  test "#-@ returns the negative version" do
+    assert_equal Magic.new(-2, :magic_missile), -@two
+  end
+end

--- a/test/conversion_table_test.rb
+++ b/test/conversion_table_test.rb
@@ -1,0 +1,19 @@
+require "test_helper"
+
+class Measured::ConversionTableTest < ActiveSupport::TestCase
+  setup do
+    @unit = Measured::Unit.new(:test)
+  end
+
+  test "#initialize accepts a list of units and a base unit" do
+    Measured::ConversionTable.new([@unit])
+  end
+
+  test "#to_h should return a hash for the simple case" do
+    expected = {
+      "test" => {"test" => BigDecimal("1")}
+    }
+
+    assert_equal expected, Measured::ConversionTable.new([@unit]).to_h
+  end
+end

--- a/test/conversion_test.rb
+++ b/test/conversion_test.rb
@@ -1,0 +1,206 @@
+require "test_helper"
+
+class Measured::ConversionTest < ActiveSupport::TestCase
+  setup do
+    @conversion = Measured::Conversion.new
+  end
+
+  test "#base sets the base unit" do
+    @conversion.set_base :m, aliases: [:metre]
+    assert_equal ["m", "metre"], @conversion.base_unit.names
+  end
+
+  test "#base doesn't allow a second base to be added" do
+    @conversion.set_base :m, aliases: [:metre]
+
+    assert_raises Measured::UnitError do
+      @conversion.set_base :in
+    end
+  end
+
+  test "#add adds a new unit" do
+    @conversion.set_base :m
+    @conversion.add :in, aliases: [:inch], value: "0.0254 meter"
+
+    assert_equal 2, @conversion.units.count
+  end
+
+  test "#add cannot add duplicate unit names" do
+    @conversion.set_base :m
+    @conversion.add :in, aliases: [:inch], value: "0.0254 meter"
+
+    assert_raises Measured::UnitError do
+      @conversion.add :in, aliases: [:thing], value: "123 m"
+    end
+
+    assert_raises Measured::UnitError do
+      @conversion.add :inch, value: "123 m"
+    end
+  end
+
+  test "#add does not allow you to add a unit before the base" do
+    assert_raises Measured::UnitError do
+      @conversion.add :in, aliases: [:inch], value: "0.0254 meter"
+    end
+  end
+
+  test "#unit_names_with_aliases lists all allowed unit names" do
+    @conversion.set_base :m
+    @conversion.add :in, aliases: [:inch], value: "0.0254 meter"
+    @conversion.add :ft, aliases: [:feet, :foot], value: "0.3048 meter"
+
+    assert_equal ["feet", "foot", "ft", "in", "inch", "m"], @conversion.unit_names_with_aliases
+  end
+
+  test "#unit_names lists all base unit names without aliases" do
+    @conversion.set_base :m
+    @conversion.add :in, aliases: [:inch], value: "0.0254 meter"
+    @conversion.add :ft, aliases: [:feet, :foot], value: "0.3048 meter"
+
+    assert_equal ["ft", "in", "m"], @conversion.unit_names
+  end
+
+  test "#unit? checks if the unit is part of the units and aliases" do
+    @conversion.set_base :m
+    @conversion.add :inch, aliases: [:in], value: "0.0254 meter"
+
+    assert @conversion.unit?(:inch)
+    assert @conversion.unit?("m")
+    refute @conversion.unit?("in")
+    refute @conversion.unit?(:yard)
+  end
+
+  test "#unit_or_alias? checks if the unit is part of the units but not aliases" do
+    @conversion.set_base :m
+    @conversion.add :inch, aliases: [:in], value: "0.0254 meter"
+
+    assert @conversion.unit_or_alias?(:inch)
+    assert @conversion.unit_or_alias?("m")
+    assert @conversion.unit_or_alias?("in")
+    refute @conversion.unit_or_alias?(:yard)
+  end
+
+  test "#to_unit_name converts a unit name to its base unit" do
+    assert_equal "fireball", Magic.conversion.to_unit_name("fire")
+  end
+
+  test "#to_unit_name does not care about string or symbol" do
+    assert_equal "fireball", Magic.conversion.to_unit_name(:fire)
+  end
+
+  test "#to_unit_name passes through if already base unit name" do
+    assert_equal "fireball", Magic.conversion.to_unit_name("fireball")
+  end
+
+  test "#to_unit_name raises if not found" do
+    assert_raises Measured::UnitError do
+      Magic.conversion.to_unit_name("thunder")
+    end
+  end
+
+  test "#convert raises if either unit is not found" do
+    assert_raises Measured::UnitError do
+      Magic.conversion.convert(1, from: "fire", to: "doesnt_exist")
+    end
+
+    assert_raises Measured::UnitError do
+      Magic.conversion.convert(1, from: "doesnt_exist", to: "fire")
+    end
+  end
+
+  test "#convert converts betwen two known units" do
+    @conversion.set_base :m
+    @conversion.add :cm, value: "0.01 m"
+
+    assert_equal BigDecimal("10"), @conversion.convert(BigDecimal("1000"), from: "cm", to: "m")
+    assert_equal BigDecimal("250"), @conversion.convert(BigDecimal("2.5"), from: "m", to: "cm")
+  end
+
+  test "#convert handles the same unit" do
+    @conversion.set_base :m
+    @conversion.add :cm, value: "0.01 m"
+
+    assert_equal BigDecimal("2"), @conversion.convert(BigDecimal("2"), from: "cm", to: "cm")
+  end
+
+  test "#conversion_table returns expected nested hashes with BigDecimal conversion factors in a tiny data set" do
+    @conversion.set_base :m
+    @conversion.add :cm, value: "0.01 m"
+
+    expected = {
+      "m"  => {
+        "m"  => BigDecimal("1"),
+        "cm" => BigDecimal("100")
+      },
+      "cm" => {
+        "cm" => BigDecimal("1"),
+        "m"  => BigDecimal("0.01")
+      }
+    }
+
+    assert_equal expected, @conversion.conversion_table
+  end
+
+  test "#conversion_table returns expected nested hashes with BigDecimal conversion factors" do
+    @conversion.set_base :m
+    @conversion.add :cm, value: "0.01 m"
+    @conversion.add :mm, value: "0.001 m"
+
+    expected = {
+      "m"  => {
+        "m"  => BigDecimal("1"),
+        "cm" => BigDecimal("100"),
+        "mm" => BigDecimal("1000")
+      },
+      "cm" => {
+        "cm" => BigDecimal("1"),
+        "m"  => BigDecimal("0.01"),
+        "mm" => BigDecimal("10")
+      },
+      "mm" => {
+        "mm" => BigDecimal("1"),
+        "m"  => BigDecimal("0.001"),
+        "cm" => BigDecimal("0.1")
+      }
+    }
+
+    assert_equal expected, @conversion.conversion_table
+  end
+
+  test "#conversion_table returns expected nested hashes with BigDecimal conversion factors in an indrect path" do
+    @conversion.set_base :mm
+    @conversion.add :cm, value: "10 mm"
+    @conversion.add :dm, value: "10 cm"
+    @conversion.add :m, value: "10 dm"
+
+    expected = {
+      "m"  => {
+        "m"  => BigDecimal("1"),
+        "cm" => BigDecimal("100"),
+        "dm" => BigDecimal("10"),
+        "mm" => BigDecimal("1000")
+      },
+      "cm" => {
+        "cm" => BigDecimal("1"),
+        "dm" => BigDecimal("0.1"),
+        "m"  => BigDecimal("0.01"),
+        "mm" => BigDecimal("10")
+      },
+      "dm" => {
+        "dm" => BigDecimal("1"),
+        "cm" => BigDecimal("10"),
+        "m"  => BigDecimal("0.1"),
+        "mm" => BigDecimal("100")
+      },
+      "mm" => {
+        "mm" => BigDecimal("1"),
+        "m"  => BigDecimal("0.001"),
+        "dm"  => BigDecimal("0.01"),
+        "cm" => BigDecimal("0.1")
+      }
+    }
+
+    assert_equal expected, @conversion.conversion_table
+  end
+
+end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -1,0 +1,118 @@
+require "test_helper"
+
+class Measured::MeasurableTest < ActiveSupport::TestCase
+
+  setup do
+    @magic = Magic.new(10, :magic_missile)
+  end
+
+  test "#initialize requires two params, the amount and the unit" do
+    assert_nothing_raised do
+      Magic.new(1, "fireball")
+    end
+
+    assert_raises ArgumentError do
+      Magic.new(1)
+    end
+  end
+
+  test "#initialize converts unit to string from symbol" do
+    magic = Magic.new(1, :arcane)
+    assert_equal "arcane", magic.unit
+  end
+
+  test "#initialize raises if it is an unknown unit" do
+    assert_raises Measured::UnitError do
+      Magic.new(1, "slash")
+    end
+  end
+
+  test "#initialize converts numbers and strings into BigDecimal" do
+    assert_equal BigDecimal(1), Magic.new(1, :arcane).value
+    assert_equal BigDecimal("2.3"), Magic.new("2.3", :arcane).value
+    assert_equal BigDecimal("5"), Magic.new("5", :arcane).value
+  end
+
+  test "#initialize converts to the base unit name" do
+    assert_equal "fireball", Magic.new(1, :fire).unit
+  end
+
+  test "#unit allows you to read the unit string" do
+    assert_equal "magic_missile", @magic.unit
+  end
+
+  test "#value allows you to read the numeric value" do
+    assert_equal BigDecimal(10), @magic.value
+  end
+
+  test ".conversion is set and cached" do
+    conversion = Magic.conversion
+
+    assert_instance_of Measured::Conversion, conversion
+    assert_equal conversion, Magic.conversion
+  end
+
+  test ".units returns just the base units" do
+    assert_equal ["arcane", "fireball", "ice", "magic_missile", "ultima"], Magic.units
+  end
+
+  test ".units_with_aliases returns all units" do
+    assert_equal ["arcane", "fire", "fireball", "fireballs", "ice", "magic_missile", "magic_missiles", "ultima"], Magic.units_with_aliases
+  end
+
+  test "#convert_to raises on an invalid unit" do
+    assert_raises Measured::UnitError do
+      @magic.convert_to(:punch)
+    end
+  end
+
+  test "#convert_to returns a new object of the same type in the new unit" do
+    converted = @magic.convert_to(:arcane)
+
+    refute_equal converted, @magic
+    assert_equal BigDecimal(10), @magic.value
+    assert_equal "magic_missile", @magic.unit
+    assert_equal BigDecimal(1), converted.value
+    assert_equal "arcane", converted.unit
+  end
+
+  test "#convert_to! replaces the existing object with a new version in the new unit" do
+    converted = @magic.convert_to!(:arcane)
+
+    assert_equal converted, @magic
+    assert_equal BigDecimal(1), @magic.value
+    assert_equal "arcane", @magic.unit
+    assert_equal BigDecimal(1), converted.value
+    assert_equal "arcane", converted.unit
+  end
+
+  test "#to_s outputs the number and the unit" do
+    assert_equal "10 fireball", Magic.new(10, :fire).to_s
+    assert_equal "1.234 magic_missile", Magic.new("1.234", :magic_missile).to_s
+  end
+
+  test "#inspect shows the number and the unit" do
+    assert_equal "#<Magic: 0.1E2 fireball>", Magic.new(10, :fire).inspect
+    assert_equal "#<Magic: 0.1234E1 magic_missile>", Magic.new("1.234", :magic_missile).inspect
+  end
+
+  test "#<=> compares only if the class and unit are the same" do
+    assert_nil @magic <=> Magic.new(10, :fire)
+    assert_equal 1, @magic <=> Magic.new(9, :magic_missile)
+    assert_equal 0, @magic <=> Magic.new(10, :magic_missile)
+    assert_equal -1, @magic <=> Magic.new(11, :magic_missile)
+  end
+
+  test "#== should be the same if the classes, unit, and amount match" do
+    assert @magic == @magic
+    assert Magic.new(10, :magic_missile) == Magic.new("10", "magic_missile")
+    refute Magic.new(1, :arcane) == Magic.new(10, :magic_missile)
+  end
+
+  test "#eql? should be the same if the classes, unit, and amount match" do
+    assert @magic == @magic
+    assert Magic.new(10, :magic_missile) == Magic.new("10", "magic_missile")
+    refute Magic.new(1, :arcane) == Magic.new(10, :magic_missile)
+  end
+
+end

--- a/test/support/fake_system.rb
+++ b/test/support/fake_system.rb
@@ -1,0 +1,26 @@
+class Magic < Measured::Measurable
+
+  conversion.set_base :magic_missile,
+    aliases: [:magic_missiles]
+
+  conversion.add :fireball,
+    aliases: [:fire, :fireballs],
+    value: "2/3 magic_missile"
+
+  conversion.add :ice,
+    value: "2 magic_missile"
+
+  conversion.add :arcane,
+    value: "10 magic_missile"
+
+  conversion.add :ultima,
+    value: "10 arcane"
+
+end
+
+class OtherFakeSystem < Measured::Measurable
+
+  conversion.set_base :other_fake_base
+  conversion.add :other_fake1, value: "2 other_fake_base"
+
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,0 +1,20 @@
+require "measured"
+require "minitest/autorun"
+require "mocha/setup"
+require "pry"
+
+ActiveSupport.test_order = :random
+
+require "support/fake_system"
+
+class ActiveSupport::TestCase
+
+  protected
+
+  def assert_conversion(klass, from, to)
+    from_amount, from_unit = from.split(" ")
+    to_amount, to_unit = to.split(" ")
+
+    assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
+  end
+end

--- a/test/unit_error_test.rb
+++ b/test/unit_error_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class Measured::UnitErrorTest < ActiveSupport::TestCase
+  test "error class exists and is a subclass of StandardError" do
+    assert Measured::UnitError.ancestors.include?(StandardError)
+  end
+end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,0 +1,77 @@
+require "test_helper"
+
+class Measured::UnitTest < ActiveSupport::TestCase
+  setup do
+    @unit = Measured::Unit.new(:pie, value: "10 cake")
+  end
+
+  test "#initialize converts the name to a string" do
+    assert_equal "pie", @unit.name
+  end
+
+  test "#initialize converts aliases to strings and makes a list of names which includes the base" do
+    assert_equal ["cake", "pie", "sweets"], Measured::Unit.new(:pie, aliases: ["cake", :sweets]).names
+  end
+
+  test "#initialize parses out the unit and the number part" do
+    assert_equal BigDecimal(10), @unit.conversion_amount
+    assert_equal "cake", @unit.conversion_unit
+
+    unit = Measured::Unit.new(:pie, value: "5.5 sweets")
+    assert_equal BigDecimal("5.5"), unit.conversion_amount
+    assert_equal "sweets", unit.conversion_unit
+  end
+
+  test "#initialize raises if the format of the value is incorrect" do
+    assert_raises Measured::UnitError do
+      Measured::Unit.new(:pie, value: "hello")
+    end
+
+    assert_raises Measured::UnitError do
+      Measured::Unit.new(:pie, value: "pie is delicious")
+    end
+
+    assert_raises Measured::UnitError do
+      Measured::Unit.new(:pie, value: "123456")
+    end
+  end
+
+  test "#to_s" do
+    assert_equal "pie", Measured::Unit.new(:pie).to_s
+    assert_equal "pie (1/2 sweet)", Measured::Unit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).to_s
+  end
+
+  test "#inspect returns an expected string" do
+    assert_equal "#<Measured::Unit: pie (pie) >", Measured::Unit.new(:pie).inspect
+    assert_equal "#<Measured::Unit: pie (cake, pie) 1/2 sweet>", Measured::Unit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).inspect
+  end
+
+  test "is comparable" do
+    assert Measured::Unit.ancestors.include?(Comparable)
+  end
+
+  test "#<=> delegates down to name for non Unit comparisons" do
+    assert_equal 1, @unit <=> "anything"
+  end
+
+  test "#<=> is equal for same values" do
+    assert_equal 0, @unit <=> Measured::Unit.new(:pie, value: "10 cake")
+    assert_equal 0, @unit <=> Measured::Unit.new("pie", value: "10 cake")
+    assert_equal 0, @unit <=> Measured::Unit.new("pie", value: [10, :cake])
+  end
+
+  test "#<=> is slightly different" do
+    assert_equal 1, @unit <=> Measured::Unit.new(:pies, value: "10 cake")
+    assert_equal 1, @unit <=> Measured::Unit.new("pie", aliases: ["pies"], value: "10 cake")
+    assert_equal 1, @unit <=> Measured::Unit.new(:pie, value: [11, :cake])
+  end
+
+  test "#inverse_conversion_amount returns 1/amount for BigDecimal" do
+    assert_equal BigDecimal(1)/BigDecimal(10), @unit.inverse_conversion_amount
+  end
+
+  test "#inverse_conversion_amount swaps the numerator and denominator for Rational" do
+    unit = Measured::Unit.new(:pie, value: [Rational(3, 7), "cake"])
+    assert_equal Rational(7, 3), unit.inverse_conversion_amount
+  end
+end

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -1,0 +1,160 @@
+require "test_helper"
+
+class Measured::LengthTest < ActiveSupport::TestCase
+  test ".units_with_aliases should be the expected list of valid units" do
+    assert_equal ["centimeter", "centimeters", "centimetre", "centimetres", "cm", "feet", "foot", "ft", "in", "inch", "inches", "m", "meter", "meters", "metre", "metres", "millimeter", "millimeters", "millimetre", "millimetres", "mm", "yard", "yards", "yd"], Measured::Length.units_with_aliases
+  end
+
+  test ".units should be the list of base units" do
+    assert_equal ["cm", "ft", "in", "m", "mm", "yd"], Measured::Length.units
+  end
+
+  test ".convert_to from cm to cm" do
+    assert_conversion Measured::Length, "2000 cm", "2000 cm"
+  end
+
+  test ".convert_to from cm to ft" do
+    assert_conversion Measured::Length, "2000 cm", "0.656167979E2 ft"
+  end
+
+  test ".convert_to from cm to in" do
+    assert_conversion Measured::Length, "2000 cm", "0.7874015748E3 in"
+  end
+
+  test ".convert_to from cm to m" do
+    assert_conversion Measured::Length, "2000 cm", "20 m"
+  end
+
+  test ".convert_to from cm to mm" do
+    assert_conversion Measured::Length, "2000 cm", "20000 mm"
+  end
+
+  test ".convert_to from cm to yd" do
+    assert_conversion Measured::Length, "2000 cm", "0.2187226596E2 yd"
+  end
+
+  test ".convert_to from ft to cm" do
+    assert_conversion Measured::Length, "2000 ft", "60960 cm"
+  end
+
+  test ".convert_to from ft to ft" do
+    assert_conversion Measured::Length, "2000 ft", "2000 ft"
+  end
+
+  test ".convert_to from ft to in" do
+    skip "returns 0.23999999999904E5"
+    assert_conversion Measured::Length, "2000 ft", "24000 in"
+  end
+
+  test ".convert_to from ft to m" do
+    assert_conversion Measured::Length, "2000 ft", "609.6 m"
+  end
+
+  test ".convert_to from ft to mm" do
+    assert_conversion Measured::Length, "2000 ft", "609600 mm"
+  end
+
+  test ".convert_to from ft to yd" do
+    skip "returns 0.6666666664608E3"
+    assert_conversion Measured::Length, "2000 ft", "0.666666667E3 yd"
+  end
+
+  test ".convert_to from in to cm" do
+    assert_conversion Measured::Length, "2000 in", "5080 cm"
+  end
+
+  test ".convert_to from in to ft" do
+    assert_conversion Measured::Length, "2000 in", "0.166666666666E3 ft"
+  end
+
+  test ".convert_to from in to in" do
+    assert_conversion Measured::Length, "2000 in", "2000 in"
+  end
+
+  test ".convert_to from in to m" do
+    assert_conversion Measured::Length, "2000 in", "50.8 m"
+  end
+
+  test ".convert_to from in to mm" do
+    assert_conversion Measured::Length, "2000 in", "50800 mm"
+  end
+
+  test ".convert_to from in to yd" do
+    assert_conversion Measured::Length, "2000 in", "0.555555555384E2 yd"
+  end
+
+  test ".convert_to from m to cm" do
+    assert_conversion Measured::Length, "2000 m", "200000 cm"
+  end
+
+  test ".convert_to from m to ft" do
+    assert_conversion Measured::Length, "2000 m", "0.656167979E4 ft"
+  end
+
+  test ".convert_to from m to in" do
+    assert_conversion Measured::Length, "2000 m", "0.7874015748E5 in"
+  end
+
+  test ".convert_to from m to m" do
+    assert_conversion Measured::Length, "2000 m", "2000 m"
+  end
+
+  test ".convert_to from m to mm" do
+    assert_conversion Measured::Length, "2000 m", "2000000 mm"
+  end
+
+  test ".convert_to from m to yd" do
+    assert_conversion Measured::Length, "2000 m", "0.2187226596E4 yd"
+  end
+
+  test ".convert_to from mm to cm" do
+    assert_conversion Measured::Length, "2000 mm", "200 cm"
+  end
+
+  test ".convert_to from mm to ft" do
+    assert_conversion Measured::Length, "2000 mm", "0.656167979E1 ft"
+  end
+
+  test ".convert_to from mm to in" do
+    assert_conversion Measured::Length, "2000 mm", "0.7874015748E2 in"
+  end
+
+  test ".convert_to from mm to m" do
+    assert_conversion Measured::Length, "2000 mm", "2 m"
+  end
+
+  test ".convert_to from mm to mm" do
+    assert_conversion Measured::Length, "2000 mm", "2000 mm"
+  end
+
+  test ".convert_to from mm to yd" do
+    assert_conversion Measured::Length, "2000 mm", "0.2187226596E1 yd"
+  end
+
+  test ".convert_to from yd to cm" do
+    assert_conversion Measured::Length, "2000 yd", "0.18288E6 cm"
+  end
+
+  test ".convert_to from yd to ft" do
+    skip "returns 0.5999999999976E4"
+    assert_conversion Measured::Length, "2000 yd", "6000 ft"
+  end
+
+  test ".convert_to from yd to in" do
+    skip "returns 0.71999999999712E5"
+    assert_conversion Measured::Length, "2000 yd", "72000 in"
+  end
+
+  test ".convert_to from yd to m" do
+    assert_conversion Measured::Length, "2000 yd", "1828.8 m"
+  end
+
+  test ".convert_to from yd to mm" do
+    assert_conversion Measured::Length, "2000 yd", "1828800 mm"
+  end
+
+  test ".convert_to from yd to yd" do
+    assert_conversion Measured::Length, "2000 yd", "2000 yd"
+  end
+
+end

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -1,0 +1,80 @@
+require "test_helper"
+
+class Measured::WeightTest < ActiveSupport::TestCase
+  setup do
+    @weight = Measured::Weight.new(1, "g")
+  end
+
+  test ".units_with_aliases should be the expected list of valid units" do
+    assert_equal ["g", "gram", "grams", "kg", "kilogram", "kilograms", "lb", "lbs", "ounce", "ounces", "oz", "pound", "pounds"], Measured::Weight.units_with_aliases
+  end
+
+  test ".units should be the list of base units" do
+    assert_equal ["g", "kg", "lb", "oz"], Measured::Weight.units
+  end
+
+  test ".convert_to from g to g" do
+    assert_conversion Measured::Weight, "2000 g", "2000 g"
+  end
+
+  test ".convert_to from g to kg" do
+    assert_conversion Measured::Weight, "2000 g", "2 kg"
+  end
+
+  test ".convert_to from g to lb" do
+    assert_conversion Measured::Weight, "2000 g", "4.40924524 lb"
+  end
+
+  test ".convert_to from g to oz" do
+    assert_conversion Measured::Weight, "2000 g", "70.54792384 oz"
+  end
+
+  test ".convert_to from kg to g" do
+    assert_conversion Measured::Weight, "2000 kg", "2000000 g"
+  end
+
+  test ".convert_to from kg to kg" do
+    assert_conversion Measured::Weight, "2000 kg", "2000 kg"
+  end
+
+  test ".convert_to from kg to lb" do
+    assert_conversion Measured::Weight, "2000 kg", "4409.24524 lb"
+  end
+
+  test ".convert_to from kg to oz" do
+    assert_conversion Measured::Weight, "2000 kg", "70547.92384 oz"
+  end
+
+  test ".convert_to from lb to g" do
+    assert_conversion Measured::Weight, "2000 lb", "907184.74 g"
+  end
+
+  test ".convert_to from lb to kg" do
+    assert_conversion Measured::Weight, "2000 lb", "907.18474 kg"
+  end
+
+  test ".convert_to from lb to lb" do
+    assert_conversion Measured::Weight, "2000 lb", "2000 lb"
+  end
+
+  test ".convert_to from lb to oz" do
+    assert_conversion Measured::Weight, "2000 lb", "32000 oz"
+  end
+
+  test ".convert_to from oz to g" do
+    assert_conversion Measured::Weight, "2000 oz", "56699.04625 g"
+  end
+
+  test ".convert_to from oz to kg" do
+    assert_conversion Measured::Weight, "2000 oz", "56.69904625 kg"
+  end
+
+  test ".convert_to from oz to lb" do
+    assert_conversion Measured::Weight, "2000 oz", "125 lb"
+  end
+
+  test ".convert_to from oz to oz" do
+    assert_conversion Measured::Weight, "2000 oz", "2000 oz"
+  end
+
+end


### PR DESCRIPTION
@Shopify/shipping @maartenvg @celsodantas @boourns @jnormore 

## What is this?

This is version 0.0.1 of a library I have written to encapsulate measurements, weight and dimensions to start with, in a single object.

Currently in Shopify we juggle two different properties which really define a single weight or dimension. We do lossy math with `UnitSystem` aka `Quantified` meaning our precision is bad. And we have no atomic way of reading/writing these to columns in the DB with ActiveRecord without juggling the fields by ourselves.

All math is done in this gem with `BigDecimal`. Conversions are extensible.

## Features

I wrote a detailed README. Read it. Please:

https://github.com/Shopify/measured/blob/version-0.0.1/README.md

## Why build from scratch?

There are two unit management libs I could find of note. They are contrasted in the README.

**tl;dr** `Quantified` in ActiveShipping does only float math and pluralizes all units. Its core assumptions are inaccurate. The `ruby-units` overrides nearly all core types and depends on those internally. Plus it is huge. Neither have ActiveRecord adapters anyway.

## Next steps

Writing a `measured-rails` adapter for ActiveRecord which understands measured objects and how to store them in columns and convert them. Inspiration for this will be taken from the Money gem.

Something roughly like:

```ruby
class Box < ActiveRecord::Base
  dimension_column :length
end
```
Which will load/store data in `length_amount` and `length_unit` columns, with optionally normalizing to `length_amount_mm` or whatever.