### PR TITLE
Required significant digits for float conversion

### DIFF
--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -50,6 +50,10 @@ class Measured::Conversion
     @conversion_table ||= Measured::ConversionTable.new(@units).to_h
   end
 
+  def significant_digits
+    6
+  end
+
   private
 
   def add_new_unit(unit_name, aliases:, value: nil, base: false)

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -7,8 +7,14 @@ class Measured::Measurable
   def initialize(value, unit)
     raise Measured::UnitError, "Unit #{ unit } does not exits." unless self.class.conversion.unit_or_alias?(unit)
 
-    @value = value
-    @value = BigDecimal(@value) unless @value.is_a?(BigDecimal)
+    @value = case value
+    when Float
+      BigDecimal(value, self.class.conversion.significant_digits)
+    when BigDecimal
+      value
+    else
+      BigDecimal(value)
+    end
 
     @unit = self.class.conversion.to_unit_name(unit)
   end

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/test/conversion_test.rb
+++ b/test/conversion_test.rb
@@ -98,6 +98,10 @@ class Measured::ConversionTest < ActiveSupport::TestCase
     end
   end
 
+  test "#significatn_digits is fixed for now" do
+    assert_equal 6, @conversion.significant_digits
+  end
+
   test "#convert raises if either unit is not found" do
     assert_raises Measured::UnitError do
       Magic.conversion.convert(1, from: "fire", to: "doesnt_exist")

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -33,6 +33,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal BigDecimal("5"), Magic.new("5", :arcane).value
   end
 
+  test "#initialize converts floats to strings and then to BigDecimal so it does not raise" do
+    assert_equal BigDecimal("1.2345"), Magic.new(1.2345, :fire).value
+  end
+
   test "#initialize converts to the base unit name" do
     assert_equal "fireball", Magic.new(1, :fire).unit
   end
@@ -100,7 +104,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test "#inspect shows the number and the unit" do
     assert_equal "#<Magic: 0.1E2 fireball>", Magic.new(10, :fire).inspect
-    assert_equal "#<Magic: 0.1234E1 magic_missile>", Magic.new("1.234", :magic_missile).inspect
+    assert_equal "#<Magic: 0.1234E1 magic_missile>", Magic.new(1.234, :magic_missile).inspect
   end
 
   test "#<=> compares only if the class and unit are the same" do


### PR DESCRIPTION
@Shopify/shipping 

When converting from a `Float` to a `BigDecimal` Ruby requires the number of significant digits to be specified. This means that if we have `1.2345678` and we say two digits it knows to convert it to `BigDecimal(1.23)`.

Failing to do so raises:

```
ArgumentError: can't omit precision for a Float.
```