### PR TITLE
Delegate to_f and to_i

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -35,6 +35,14 @@ class Measured::Measurable
     self
   end
 
+  def to_i
+    Kernel.Integer(value)
+  end
+
+  def to_f
+    Kernel.Float(value)
+  end
+
   def to_s
     [value.to_f.to_s.gsub(/\.0\Z/, ""), unit].join(" ")
   end

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -97,6 +97,14 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "arcane", converted.unit
   end
 
+  test "#to_i is delegated to the value" do
+    assert_equal 10, @magic.to_i
+  end
+
+  test "#to_f is delegated to the value" do
+    assert_equal 10.0, @magic.to_f
+  end
+
   test "#to_s outputs the number and the unit" do
     assert_equal "10 fireball", Magic.new(10, :fire).to_s
     assert_equal "1.234 magic_missile", Magic.new("1.234", :magic_missile).to_s


### PR DESCRIPTION
@Shopify/shipping 

In order for us to be able to use rails numericality validations, the `Measurable` subclasses have to respond to `to_f` and `to_i` in order to coerce them into a numeric.