### PR TITLE
Initialize with nil

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -8,6 +8,8 @@ class Measured::Measurable
     raise Measured::UnitError, "Unit #{ unit } does not exits." unless self.class.conversion.unit_or_alias?(unit)
 
     @value = case value
+    when NilClass
+      raise Measured::UnitError, "Unit value cannot be nil"
     when Float
       BigDecimal(value, self.class.conversion.significant_digits)
     when BigDecimal

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -41,6 +41,12 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "fireball", Magic.new(1, :fire).unit
   end
 
+  test "#initialize raises an expected error when initializing with nil" do
+    assert_raises Measured::UnitError do
+      Magic.new(nil, :fire)
+    end
+  end
+
   test "#unit allows you to read the unit string" do
     assert_equal "magic_missile", @magic.unit
   end


### PR DESCRIPTION
@Shopify/shipping 

If you initialized a measurement with `nil` as the value, previously it would attempt to parse it as a string internally and raise a very unclear error. 

Raise explicitly for `nil` values.