### PR TITLE
Add .name helper to Measurable

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -75,5 +75,9 @@ class Measured::Measurable
       conversion.unit_names_with_aliases
     end
 
+    def name
+      to_s.split("::").last.underscore.humanize.downcase
+    end
+
   end
 end

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -77,6 +77,16 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     refute Magic.valid_unit?("junk")
   end
 
+  test ".name looks at the class name" do
+    module Example
+      class VeryComplexThing < Measured::Measurable ; end
+    end
+
+    assert_equal "magic", Magic.name
+    assert_equal "measurable", Measured::Measurable.name
+    assert_equal "very complex thing", Example::VeryComplexThing.name
+  end
+
   test "#convert_to raises on an invalid unit" do
     assert_raises Measured::UnitError do
       @magic.convert_to(:punch)

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -9,6 +9,10 @@ class Measured::LengthTest < ActiveSupport::TestCase
     assert_equal ["cm", "ft", "in", "m", "mm", "yd"], Measured::Length.units
   end
 
+  test ".name" do
+    assert_equal "length", Measured::Length.name
+  end
+
   test ".convert_to from cm to cm" do
     assert_conversion Measured::Length, "2000 cm", "2000 cm"
   end

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -13,6 +13,10 @@ class Measured::WeightTest < ActiveSupport::TestCase
     assert_equal ["g", "kg", "lb", "oz"], Measured::Weight.units
   end
 
+  test ".name" do
+    assert_equal "weight", Measured::Weight.name
+  end
+
   test ".convert_to from g to g" do
     assert_conversion Measured::Weight, "2000 g", "2000 g"
   end


### PR DESCRIPTION
@Shopify/shipping 

Add a helper for the name of the measurable. I want to use it for clearer validation messages in [measured-rails](https://github.com/Shopify/measured-rails). It can be easily overridden on the subclasses if needed.