### PR TITLE
Convert as required when doing comparison between different units

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ Measured::Weight.new(3, :g) * 2
 > #<Measured::Weight 6 g>
 ```
 
+Converts units only as needed for equality comparison:
+
+```ruby
+> Measured::Weight.new(1000, :g) == Measured::Weight.new(1, :kg)
+true
+```
+
 Extract the unit and the value:
 
 ```ruby

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -23,6 +23,8 @@ class Measured::Measurable
 
   def convert_to(new_unit)
     new_unit_name = self.class.conversion.to_unit_name(new_unit)
+    return self if new_unit_name == self.class.conversion.to_unit_name(unit)
+
     value = self.class.conversion.convert(@value, from: @unit, to: new_unit_name)
 
     self.class.new(value, new_unit)
@@ -46,13 +48,17 @@ class Measured::Measurable
   end
 
   def <=>(other)
-    if other.is_a?(self.class) && unit == other.unit
-      value <=> other.value
+    if other.is_a?(self.class)
+      other_converted = other.convert_to(unit)
+      value <=> other_converted.value
     end
   end
 
   def ==(other)
-    !!(other.is_a?(self.class) && unit == other.unit && value == other.value)
+    return false unless other.is_a?(self.class)
+
+    other_converted = other.convert_to(unit)
+    unit == other_converted.unit && value == other_converted.value
   end
 
   alias_method :eql?, :==

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -58,7 +58,7 @@ class Measured::Measurable
     return false unless other.is_a?(self.class)
 
     other_converted = other.convert_to(unit)
-    unit == other_converted.unit && value == other_converted.value
+    value == other_converted.value
   end
 
   alias_method :eql?, :==

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end


### PR DESCRIPTION
@Shopify/shipping 

Changes implementation of comparison operators (`==`, `.eql?`, and `<=>`) to do the conversion between units. Does this only as needed.

Update the `convert_to` operator to exit early and return the measurement unchanged if the conversion is to the unit it is already in.

Example, this was false but is now true:

```ruby
> Measured::Length(1000, :cm) == Measured::Length(1, :m)
true
```