### PR TITLE
Numerical comparison against all types of zeros should be permitted

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,18 @@ Seamlessly handles aliases:
 Measured::Weight.new(12, :oz) == Measured::Weight.new("12", :ounce)
 ```
 
+Comparison with zero works without the need to specify units, useful for validations:
+```ruby
+Measured::Weight.new(0.001, :kg) > 0
+> true
+
+Measured::Length.new(-1, :m) < 0
+> true
+
+Measured::Weight.new(0, :oz) == 0
+> true
+```
+
 Raises on unknown units:
 
 ```ruby

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -51,14 +51,20 @@ class Measured::Measurable
     if other.is_a?(self.class)
       other_converted = other.convert_to(unit)
       value <=> other_converted.value
+    elsif other == 0
+      other_converted = self.class.new(0, unit)
+      value <=> other_converted.value
     end
   end
 
   def ==(other)
-    return false unless other.is_a?(self.class)
-
-    other_converted = other.convert_to(unit)
-    value == other_converted.value
+    if other.is_a?(self.class)
+      other_converted = other.convert_to(unit)
+      value == other_converted.value
+    elsif other == 0
+      other_converted = self.class.new(0, unit)
+      value == other_converted.value
+    end
   end
 
   alias_method :eql?, :==

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.6"
+  VERSION = "0.0.7"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -136,6 +136,13 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal -1, @magic <=> Magic.new(11, :magic_missile)
   end
 
+  test "#<=> compares against zero" do
+    assert_equal 1, @magic <=> 0
+    assert_equal 1, @magic <=> BigDecimal.new(0)
+    assert_equal 1, @magic <=> 0.00
+    assert_equal -1, Magic.new(-1, :magic_missile) <=> 0
+  end
+
   test "#== should be the same if the classes, unit, and amount match" do
     assert @magic == @magic
     assert Magic.new(10, :magic_missile) == Magic.new("10", "magic_missile")
@@ -147,6 +154,15 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert Magic.new(2, :magic_missile) == Magic.new("1", "ice")
   end
 
+  test "#== compares against zero" do
+    assert Magic.new(0, :fire) == 0
+    assert Magic.new(0, :magic_missile) == 0
+    assert Magic.new(0, :fire) == BigDecimal.new(0)
+    assert Magic.new(0, :fire) == 0.00
+    refute @magic == 0
+    refute @magic == BigDecimal.new(0)
+  end
+
   test "#> and #< should compare measurements" do
     assert Magic.new(10, :magic_missile) < Magic.new(20, :magic_missile)
     refute Magic.new(10, :magic_missile) > Magic.new(20, :magic_missile)
@@ -155,6 +171,15 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   test "#> and #< should compare measurements of different units" do
     assert Magic.new(10, :magic_missile) < Magic.new(100, :ice)
     refute Magic.new(10, :magic_missile) > Magic.new(100, :ice)
+  end
+
+  test "#> and #< should compare against zero" do
+    assert @magic > 0
+    assert @magic > BigDecimal.new(0)
+    assert @magic > 0.00
+    assert Magic.new(-1, :arcane) < 0
+    refute @magic < 0
+    refute Magic.new(-1, :arcane) > 0
   end
 
   test "#eql? should be the same if the classes and amount match, and unit is converted" do


### PR DESCRIPTION
@Shopify/shipping 

Previously, comparing a ```Measured::Measurable``` against any scalar raised an ```ArgumentError``` since it expects all arguments being compared to be of the same class. This prevented us from comparing against ```0``` which is a pretty good UX for this gem. Comparison with zeros of ```BigDecimal``` (i.e ```BigDecimal.new(0)```) and ```Float``` (i.e ```0.0```) work as expected. 

Comparing ```Measured::Measurable``` objects against other non-zero scalars still raises an error just like before.

Example:
```ruby
x = Measured::Length(2, :m)
x > 0  ## evaluates to true
x < 0.0 ## evaluates to false
x == BigDecimal.new(0) ## also false

x == 2 ## ArgumentError
```