### PR TITLE
Removing bundler from measured

### DIFF
--- a/measured.gemspec
+++ b/measured.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", ">= 4.0"
 
-  spec.add_development_dependency "bundler", "~> 1.8"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"
   spec.add_development_dependency "mocha", "~> 1.1.0"


### PR DESCRIPTION
**Context**
We use shipit to deploy measured to rubygems. Shipit currently pegged at bundler v1.7.3 and doesn't support v1.8 and above. 

It doesn't seem like we need bundler > 1.7.3 for this gem.

@Shopify/shipping @kmcphillips 