### PR TITLE
Round floats to six digits, not six significant digits.

### DIFF
--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -50,10 +50,6 @@ class Measured::Conversion
     @conversion_table ||= Measured::ConversionTable.new(@units).to_h
   end
 
-  def significant_digits
-    6
-  end
-
   private
 
   def add_new_unit(unit_name, aliases:, value: nil, base: false)

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -11,7 +11,7 @@ class Measured::Measurable
     when NilClass
       raise Measured::UnitError, "Unit value cannot be nil"
     when Float
-      BigDecimal(value, self.class.conversion.significant_digits)
+      BigDecimal(value, Float::DIG+1)
     when BigDecimal
       value
     else

--- a/test/conversion_test.rb
+++ b/test/conversion_test.rb
@@ -98,10 +98,6 @@ class Measured::ConversionTest < ActiveSupport::TestCase
     end
   end
 
-  test "#significatn_digits is fixed for now" do
-    assert_equal 6, @conversion.significant_digits
-  end
-
   test "#convert raises if either unit is not found" do
     assert_raises Measured::UnitError do
       Magic.conversion.convert(1, from: "fire", to: "doesnt_exist")

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -37,6 +37,11 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal BigDecimal("1.2345"), Magic.new(1.2345, :fire).value
   end
 
+  test "#initialize converts numbers and strings BigDecimal and does not round large numbers" do
+    assert_equal BigDecimal(9.1234572342342, 14), Magic.new(9.1234572342342, :fire).value
+    assert_equal BigDecimal("9.1234572342342"), Magic.new(9.1234572342342, :fire).value
+  end
+
   test "#initialize converts to the base unit name" do
     assert_equal "fireball", Magic.new(1, :fire).unit
   end


### PR DESCRIPTION
Let's use 6 digits to round, not six significant digits, when converting floats to `BigDecimal`.

cc @kmcphillips 