### PR TITLE
Handle exceptions for nil and blank more cleanly

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -5,7 +5,8 @@ class Measured::Measurable
   attr_reader :unit, :value
 
   def initialize(value, unit)
-    raise Measured::UnitError, "Unit #{ unit } does not exits." unless self.class.conversion.unit_or_alias?(unit)
+    raise Measured::UnitError, "Unit cannot be blank" if unit.blank?
+    raise Measured::UnitError, "Unit #{ unit } does not exits" unless self.class.conversion.unit_or_alias?(unit)
 
     @value = case value
     when NilClass
@@ -15,7 +16,11 @@ class Measured::Measurable
     when BigDecimal
       value
     else
-      BigDecimal(value)
+      if value.blank?
+        raise Measured::UnitError, "Unit value cannot be blank"
+      else
+        BigDecimal(value)
+      end
     end
 
     @unit = self.class.conversion.to_unit_name(unit)

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.8"
+  VERSION = "0.0.9"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -46,10 +46,32 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "fireball", Magic.new(1, :fire).unit
   end
 
-  test "#initialize raises an expected error when initializing with nil" do
-    assert_raises Measured::UnitError do
+  test "#initialize raises an expected error when initializing with nil value" do
+    exception = assert_raises(Measured::UnitError) do
       Magic.new(nil, :fire)
     end
+    assert_equal "Unit value cannot be nil", exception.message
+  end
+
+  test "#initialize raises an expected error when initializing with nil unit" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.new(1, nil)
+    end
+    assert_equal "Unit cannot be blank", exception.message
+  end
+
+  test "#initialize raises an expected error when initializing with empty string value" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.new("", :fire)
+    end
+    assert_equal "Unit value cannot be blank", exception.message
+  end
+
+  test "#initialize raises an expected error when initializing with empty string unit" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.new(1, "")
+    end
+    assert_equal "Unit cannot be blank", exception.message
   end
 
   test "#unit allows you to read the unit string" do


### PR DESCRIPTION
@garethson @cyprusad 

## Problem

We don't cleanly handle initializations with `nil` and `""`.

## Solution

Handle them explicitly with the same exceptions and clean names.

Bumps to `0.0.9`.