### PR TITLE
Require active_support/all correctly. Bump version 0.0.10

### DIFF
--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -1,5 +1,5 @@
 require "measured/version"
-require "active_support"
+require "active_support/all"
 require "bigdecimal"
 
 module Measured

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.9"
+  VERSION = "0.0.10"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -152,8 +152,8 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test "#inspect shows the number and the unit" do
-    assert_equal "#<Magic: 0.1E2 fireball>", Magic.new(10, :fire).inspect
-    assert_equal "#<Magic: 0.1234E1 magic_missile>", Magic.new(1.234, :magic_missile).inspect
+    assert_equal "#<Magic: 10.0 fireball>", Magic.new(10, :fire).inspect
+    assert_equal "#<Magic: 1.234 magic_missile>", Magic.new(1.234, :magic_missile).inspect
   end
 
   test "#<=> compares regardless of the unit" do


### PR DESCRIPTION
@cyprusad @garethson 

Found a `require` bug when working with @mdking. Requiring `active_support` actually doesn't include much, including many helpers that are assumed to exist:

```ruby
~/s/measured(master)$ irb
irb(main):001:0> require 'measured'
=> true
irb(main):002:0> Measured::Length.new(1, :cm)
NoMethodError: undefined method `blank?' for :cm:Symbol
	from /Users/kevin/.rbenv/versions/2.1.1/lib/ruby/gems/2.1.0/gems/measured-0.0.9/lib/measured/measurable.rb:8:in `initialize'
	from (irb):2:in `new'
	from (irb):2
	from /Users/kevin/.rbenv/versions/2.1.1/bin/irb:11:in `<main>'
```