### PR TITLE
Allow initialization from module

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,14 @@ You can skip these and only define your own units by doing:
 gem 'measured', require: 'measured/base'
 ```
 
+### Shortcut syntax
+
+There is a shortcut initialization syntax for modules inside the `Measured` namespace, similar to `BigDecimal(123)` vs `BigDecimal.new(123)`:
+
+```ruby
+Measured::Weight(1, :g)
+```
+
 ### Adding new units
 
 Extending this library to support other units is simple. To add a new conversion, subclass `Measured::Measurable`, define your base units, then add your conversion units.

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -4,6 +4,24 @@ require "bigdecimal"
 
 module Measured
   class UnitError < StandardError ; end
+
+  class << self
+    def method_missing(method, *args)
+      class_name = "Measured::#{ method }"
+
+      if Measured::Measurable.subclasses.map(&:to_s).include?(class_name)
+        klass = class_name.constantize
+
+        Measured.define_singleton_method(method) do |value, unit|
+          klass.new(value, unit)
+        end
+
+        klass.new(*args)
+      else
+        super
+      end
+    end
+  end
 end
 
 require "measured/arithmetic"

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.10"
+  VERSION = "0.0.11"
 end

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -13,6 +13,11 @@ class Measured::LengthTest < ActiveSupport::TestCase
     assert_equal "length", Measured::Length.name
   end
 
+  test "Measured::Length() delegates automatically to .new" do
+    assert_equal Measured::Length.new(1, :in), Measured::Length(1, :in)
+    assert_equal Measured::Length.new(200, :mm), Measured::Length(20, :cm)
+  end
+
   test ".convert_to from cm to cm" do
     assert_conversion Measured::Length, "2000 cm", "2000 cm"
   end

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -13,6 +13,12 @@ class Measured::WeightTest < ActiveSupport::TestCase
     assert_equal ["g", "kg", "lb", "oz"], Measured::Weight.units
   end
 
+
+  test "Measured::Weight() delegates automatically to .new" do
+    assert_equal Measured::Weight.new(1, :lb), Measured::Weight(1, :lb)
+    assert_equal Measured::Weight.new(2000, :g), Measured::Weight(2, :kg)
+  end
+
   test ".name" do
     assert_equal "weight", Measured::Weight.name
   end


### PR DESCRIPTION
@garethson @cyprusad @mdking 

Fixed a bit of syntax sugar that I have wanted for a while.

Similar to how you can initialize a `BigDecimal(123)` without the `.new` I have added some metaprogramming to allow that for any subclasses of `Measured` in the namespace.

```ruby
Measured::Length(1, :cm)
```