### PR TITLE
Use Rationals for intermediate conversion values

### DIFF
--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -1,4 +1,5 @@
 class Measured::Conversion
+  ARBITRARY_CONVERSION_PRECISION = 20
   def initialize
     @base_unit = nil
     @units = []
@@ -43,7 +44,7 @@ class Measured::Conversion
 
     raise Measured::UnitError, "Cannot find conversion entry from #{ from } to #{ to }" unless conversion = conversion_table[from][to]
 
-    value * conversion
+    BigDecimal(value.to_r * conversion,ARBITRARY_CONVERSION_PRECISION)
   end
 
   def conversion_table

--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -44,7 +44,7 @@ class Measured::ConversionTable
   end
 
   def find_tree_traversal_conversion(to:, from:)
-    traverse(from: from, to: to, unit_names: @units.map{|u| u.name }, amount: BigDecimal("1"))
+    traverse(from: from, to: to, unit_names: @units.map{|u| u.name }, amount: Rational(1)).to_d(30)
   end
 
   def traverse(from:, to:, unit_names:, amount:)
@@ -52,10 +52,11 @@ class Measured::ConversionTable
 
     unit_names.each do |name|
       if conversion = find_direct_conversion(from: from, to: name)
+        new_amount = amount * conversion.to_r
         if name == to
-          return amount * conversion
+          return new_amount
         else
-          result = traverse(from: name, to: to, unit_names: unit_names, amount: amount * conversion)
+          result = traverse(from: name, to: to, unit_names: unit_names, amount: new_amount)
           return result if result
         end
       end

--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -44,7 +44,7 @@ class Measured::ConversionTable
   end
 
   def find_tree_traversal_conversion(to:, from:)
-    traverse(from: from, to: to, unit_names: @units.map{|u| u.name }, amount: Rational(1)).to_d(30)
+    traverse(from: from, to: to, unit_names: @units.map{|u| u.name }, amount: Rational(1))
   end
 
   def traverse(from:, to:, unit_names:, amount:)

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -35,11 +35,7 @@ class Measured::Unit
   end
 
   def inverse_conversion_amount
-    if conversion_amount.is_a?(Rational)
-      Rational(conversion_amount.denominator, conversion_amount.numerator)
-    else
-      BigDecimal(1) /  conversion_amount
-    end
+    1 / conversion_amount.to_r
   end
 
   private

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "0.0.11"
+  VERSION = "0.0.12"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -25,4 +25,11 @@ class ActiveSupport::TestCase
 
     assert_close_bigdecimal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
+
+  def assert_exact_conversion(klass, from, to)
+    from_amount, from_unit = from.split(" ")
+    to_amount, to_unit = to.split(" ")
+
+    assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,6 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
-    assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
+    assert_equal BigDecimal(to_amount).round(5), klass.new(from_amount, from_unit).convert_to(to_unit).value.round(5)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,10 +11,18 @@ class ActiveSupport::TestCase
 
   protected
 
+  def assert_close_bigdecimal exp, act, delta = BigDecimal('0.000001')
+    n = (exp - act).abs
+    msg = message(msg) {
+      "Expected #{act.inspect} to be\nclose to #{exp.inspect} within #{delta} but was within #{n}"
+    }
+    assert delta >= n, msg
+  end
+
   def assert_conversion(klass, from, to)
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
-    assert_equal BigDecimal(to_amount).round(5), klass.new(from_amount, from_unit).convert_to(to_unit).value.round(5)
+    assert_close_bigdecimal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 end

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -19,7 +19,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from cm to cm" do
-    assert_conversion Measured::Length, "2000 cm", "2000 cm"
+    assert_exact_conversion Measured::Length, "2000 cm", "2000 cm"
   end
 
   test ".convert_to from cm to ft" do
@@ -31,11 +31,11 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from cm to m" do
-    assert_conversion Measured::Length, "2000 cm", "20 m"
+    assert_exact_conversion Measured::Length, "2000 cm", "20 m"
   end
 
   test ".convert_to from cm to mm" do
-    assert_conversion Measured::Length, "2000 cm", "20000 mm"
+    assert_exact_conversion Measured::Length, "2000 cm", "20000 mm"
   end
 
   test ".convert_to from cm to yd" do
@@ -47,15 +47,15 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from ft to ft" do
-    assert_conversion Measured::Length, "2000 ft", "2000 ft"
+    assert_exact_conversion Measured::Length, "2000 ft", "2000 ft"
   end
 
   test ".convert_to from ft to in" do
-    assert_conversion Measured::Length, "2000 ft", "24000 in"
+    assert_exact_conversion Measured::Length, "2000 ft", "24000 in"
   end
 
   test ".convert_to from ft to m" do
-    assert_conversion Measured::Length, "2000 ft", "609.6 m"
+    assert_exact_conversion Measured::Length, "2000 ft", "609.6 m"
   end
 
   test ".convert_to from ft to mm" do
@@ -75,7 +75,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from in to in" do
-    assert_conversion Measured::Length, "2000 in", "2000 in"
+    assert_exact_conversion Measured::Length, "2000 in", "2000 in"
   end
 
   test ".convert_to from in to m" do
@@ -103,11 +103,11 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from m to m" do
-    assert_conversion Measured::Length, "2000 m", "2000 m"
+    assert_exact_conversion Measured::Length, "2000 m", "2000 m"
   end
 
   test ".convert_to from m to mm" do
-    assert_conversion Measured::Length, "2000 m", "2000000 mm"
+    assert_exact_conversion Measured::Length, "2000 m", "2000000 mm"
   end
 
   test ".convert_to from m to yd" do
@@ -115,7 +115,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from mm to cm" do
-    assert_conversion Measured::Length, "2000 mm", "200 cm"
+    assert_exact_conversion Measured::Length, "2000 mm", "200 cm"
   end
 
   test ".convert_to from mm to ft" do
@@ -127,11 +127,11 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from mm to m" do
-    assert_conversion Measured::Length, "2000 mm", "2 m"
+    assert_exact_conversion Measured::Length, "2000 mm", "2 m"
   end
 
   test ".convert_to from mm to mm" do
-    assert_conversion Measured::Length, "2000 mm", "2000 mm"
+    assert_exact_conversion Measured::Length, "2000 mm", "2000 mm"
   end
 
   test ".convert_to from mm to yd" do
@@ -143,11 +143,11 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from yd to ft" do
-    assert_conversion Measured::Length, "2000 yd", "6000 ft"
+    assert_exact_conversion Measured::Length, "2000 yd", "6000 ft"
   end
 
   test ".convert_to from yd to in" do
-    assert_conversion Measured::Length, "2000 yd", "72000 in"
+    assert_exact_conversion Measured::Length, "2000 yd", "72000 in"
   end
 
   test ".convert_to from yd to m" do
@@ -159,7 +159,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from yd to yd" do
-    assert_conversion Measured::Length, "2000 yd", "2000 yd"
+    assert_exact_conversion Measured::Length, "2000 yd", "2000 yd"
   end
 
 end

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -23,12 +23,10 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from cm to ft" do
-    skip
     assert_conversion Measured::Length, "2000 cm", "0.656167979E2 ft"
   end
 
   test ".convert_to from cm to in" do
-    skip
     assert_conversion Measured::Length, "2000 cm", "0.7874015748E3 in"
   end
 
@@ -41,7 +39,6 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from cm to yd" do
-    skip
     assert_conversion Measured::Length, "2000 cm", "0.2187226596E2 yd"
   end
 
@@ -54,7 +51,6 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from ft to in" do
-    skip "returns 0.23999999999904E5"
     assert_conversion Measured::Length, "2000 ft", "24000 in"
   end
 
@@ -67,7 +63,6 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from ft to yd" do
-    skip "returns 0.6666666664608E3"
     assert_conversion Measured::Length, "2000 ft", "0.666666667E3 yd"
   end
 
@@ -76,7 +71,6 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from in to ft" do
-    skip
     assert_conversion Measured::Length, "2000 in", "0.166666666666E3 ft"
   end
 
@@ -93,7 +87,6 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from in to yd" do
-    skip
     assert_conversion Measured::Length, "2000 in", "0.555555555384E2 yd"
   end
 
@@ -102,12 +95,10 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from m to ft" do
-    skip
     assert_conversion Measured::Length, "2000 m", "0.656167979E4 ft"
   end
 
   test ".convert_to from m to in" do
-    skip
     assert_conversion Measured::Length, "2000 m", "0.7874015748E5 in"
   end
 
@@ -120,7 +111,6 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from m to yd" do
-    skip
     assert_conversion Measured::Length, "2000 m", "0.2187226596E4 yd"
   end
 
@@ -129,12 +119,10 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from mm to ft" do
-    skip
     assert_conversion Measured::Length, "2000 mm", "0.656167979E1 ft"
   end
 
   test ".convert_to from mm to in" do
-    skip
     assert_conversion Measured::Length, "2000 mm", "0.7874015748E2 in"
   end
 
@@ -147,22 +135,18 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from mm to yd" do
-    skip
     assert_conversion Measured::Length, "2000 mm", "0.2187226596E1 yd"
   end
 
   test ".convert_to from yd to cm" do
-    skip
     assert_conversion Measured::Length, "2000 yd", "0.18288E6 cm"
   end
 
   test ".convert_to from yd to ft" do
-    skip "returns 0.5999999999976E4"
     assert_conversion Measured::Length, "2000 yd", "6000 ft"
   end
 
   test ".convert_to from yd to in" do
-    skip "returns 0.71999999999712E5"
     assert_conversion Measured::Length, "2000 yd", "72000 in"
   end
 

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -32,12 +32,10 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from g to lb" do
-    skip
     assert_conversion Measured::Weight, "2000 g", "4.40924524 lb"
   end
 
   test ".convert_to from g to oz" do
-    skip
     assert_conversion Measured::Weight, "2000 g", "70.54792384 oz"
   end
 
@@ -50,13 +48,11 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from kg to lb" do
-    skip
     assert_conversion Measured::Weight, "2000 kg", "4409.24524 lb"
   end
 
   test ".convert_to from kg to oz" do
-    skip
-    assert_conversion Measured::Weight, "2000 kg", "70547.92384 oz"
+    assert_conversion Measured::Weight, "2000 kg", "70547.92390 oz"
   end
 
   test ".convert_to from lb to g" do
@@ -64,7 +60,6 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from lb to kg" do
-    skip
     assert_conversion Measured::Weight, "2000 lb", "907.18474 kg"
   end
 
@@ -77,12 +72,10 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from oz to g" do
-    skip
     assert_conversion Measured::Weight, "2000 oz", "56699.04625 g"
   end
 
   test ".convert_to from oz to kg" do
-    skip
     assert_conversion Measured::Weight, "2000 oz", "56.69904625 kg"
   end
 

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -24,11 +24,11 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from g to g" do
-    assert_conversion Measured::Weight, "2000 g", "2000 g"
+    assert_exact_conversion Measured::Weight, "2000 g", "2000 g"
   end
 
   test ".convert_to from g to kg" do
-    assert_conversion Measured::Weight, "2000 g", "2 kg"
+    assert_exact_conversion Measured::Weight, "2000 g", "2 kg"
   end
 
   test ".convert_to from g to lb" do
@@ -40,11 +40,11 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from kg to g" do
-    assert_conversion Measured::Weight, "2000 kg", "2000000 g"
+    assert_exact_conversion Measured::Weight, "2000 kg", "2000000 g"
   end
 
   test ".convert_to from kg to kg" do
-    assert_conversion Measured::Weight, "2000 kg", "2000 kg"
+    assert_exact_conversion Measured::Weight, "2000 kg", "2000 kg"
   end
 
   test ".convert_to from kg to lb" do
@@ -56,19 +56,19 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from lb to g" do
-    assert_conversion Measured::Weight, "2000 lb", "907184.74 g"
+    assert_exact_conversion Measured::Weight, "2000 lb", "907184.74 g"
   end
 
   test ".convert_to from lb to kg" do
-    assert_conversion Measured::Weight, "2000 lb", "907.18474 kg"
+    assert_exact_conversion Measured::Weight, "2000 lb", "907.18474 kg"
   end
 
   test ".convert_to from lb to lb" do
-    assert_conversion Measured::Weight, "2000 lb", "2000 lb"
+    assert_exact_conversion Measured::Weight, "2000 lb", "2000 lb"
   end
 
   test ".convert_to from lb to oz" do
-    assert_conversion Measured::Weight, "2000 lb", "32000 oz"
+    assert_exact_conversion Measured::Weight, "2000 lb", "32000 oz"
   end
 
   test ".convert_to from oz to g" do
@@ -80,11 +80,11 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from oz to lb" do
-    assert_conversion Measured::Weight, "2000 oz", "125 lb"
+    assert_exact_conversion Measured::Weight, "2000 oz", "125 lb"
   end
 
   test ".convert_to from oz to oz" do
-    assert_conversion Measured::Weight, "2000 oz", "2000 oz"
+    assert_exact_conversion Measured::Weight, "2000 oz", "2000 oz"
   end
 
 end

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -48,7 +48,7 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from kg to lb" do
-    assert_conversion Measured::Weight, "2000 kg", "4409.24524 lb"
+    assert_conversion Measured::Weight, "2000 kg", "4409.245243 lb"
   end
 
   test ".convert_to from kg to oz" do


### PR DESCRIPTION
Fixes #4 to some extent.

#### Problem

Measured builds a conversion table in `Measured::ConversionTable` but some values in the table would be wrong, for example the conversion value from feet to yards would not be `3`. The reason for this is Measured's tree traversal would go through the base unit `ft->m->yd` using `BigDecimal` for intermediate values but the `m->yd` can not be done with perfect precision with decimal numbers.

#### Solution

Use `Rational`s for intermediate values when building the conversion table. This means all intermediate multiplications will be done with perfect precision. Currently this fixes all the previously skipped tests.

#### Todo
- [x] Don't use new Ruby 2.2 `round(n)` feature so that CI can pass
- [x] Always give back `Rational` from `inverse_conversion_amount` because `BigDecimal` can't do this

#### Commentary

Really this issue stems from the fact that `BigDecimal` is used at all. In a perfect world the library would only ever use `Rational` because it is always perfect and never imprecise :sparkles:. By using BigDecimal we accept that some of our conversions will always be lossy, not to mention we will never be able to represent "1/3 of a meter" accurately.

I'm not sure why the library was designed to use BigDecimal at all, but IMO it might be worthwhile to make `Measured` only support `Rational` to avoid these issues. If the issue is storage space in the DB then we could always make `Measured::Rails` do the conversion to/from BigDecimal at the persistence level.

@kmcphillips @cyprusad @garethson