### PR TITLE
Case sensitivity and ability to add new aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Measured [![Build Status](https://travis-ci.org/Shopify/measured.svg)](https://travis-ci.org/Shopify/measured) [![Gem Version](https://badge.fury.io/rb/measured.svg)](http://badge.fury.io/rb/measured)
 
-Encapsulates measruements with their units. Provides easy conversion between units.
+Encapsulates measurements with their units. Provides easy conversion between units.
 
 Light weight and easily extensible to include other units and conversions. Conversions done with `BigDecimal` for precision.
 

--- a/README.md
+++ b/README.md
@@ -181,6 +181,7 @@ class Measured::Thing < Measured::Measurable
 
   conversion.add :another_unit,             # Add a second unit to the system
     aliases: [:au],                         # All units allow aliases, as long as they are unique
+    case_sensitive: true,                   # Defaults to false; applies to name and aliases
     value: ["1.5 base_unit"]                # The conversion rate to another unit
 
   conversion.add :different_unit
@@ -190,6 +191,8 @@ end
 ```
 
 The base unit takes no value. Values for conversion units can be defined as a string with two tokens `"number unit"` or as an array with two elements. The numbers must be `Rational` or `BigDecimal`, else they will be coerced to `BigDecimal`. Conversion paths don't have to be direct as a conversion table will be built for all possible conversions using tree traversal.
+
+The `case_sensitive` flag, which is false by default, gets taken into account any time you attempt to reference a unit by name or alias.
 
 You can also open up the existing classes and add a new conversion:
 

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -6,7 +6,7 @@ class Measured::Measurable
 
   def initialize(value, unit)
     raise Measured::UnitError, "Unit cannot be blank" if unit.blank?
-    raise Measured::UnitError, "Unit #{ unit } does not exits" unless self.class.conversion.unit_or_alias?(unit)
+    raise Measured::UnitError, "Unit #{ unit } does not exist" unless self.class.conversion.unit_or_alias?(unit)
 
     @value = case value
     when NilClass

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -1,14 +1,27 @@
 class Measured::Unit
   include Comparable
 
-  def initialize(name, aliases: [], value: nil)
+  def initialize(name, aliases: [], case_sensitive: false, value: nil)
     @name = name.to_s
     @names = ([@name] + aliases.map{|n| n.to_s }).sort
 
+    @case_sensitive = case_sensitive
     @conversion_amount, @conversion_unit = parse_value(value) if value
   end
 
-  attr_reader :name, :names, :conversion_amount, :conversion_unit
+  attr_reader :name, :names, :case_sensitive, :conversion_amount, :conversion_unit
+
+  def name_eql?(name_to_compare)
+    with_case_sensitivity(self.name).include?(with_case_sensitivity(name_to_compare).join)
+  end
+
+  def names_include?(name_to_compare)
+    with_case_sensitivity(self.names).include?(with_case_sensitivity(name_to_compare).join)
+  end
+
+  def add_alias(aliases)
+    @names = (@names << aliases).flatten.sort
+  end
 
   def to_s
     if conversion_string
@@ -39,6 +52,11 @@ class Measured::Unit
   end
 
   private
+
+  def with_case_sensitivity(comparison)
+    comparison = [comparison].flatten
+    case_sensitive ? comparison : comparison.map(&:downcase)
+  end
 
   def conversion_string
     "#{ conversion_amount } #{ conversion_unit }" if @conversion_amount || @conversion_unit

--- a/test/conversion_test.rb
+++ b/test/conversion_test.rb
@@ -66,8 +66,19 @@ class Measured::ConversionTest < ActiveSupport::TestCase
 
     assert @conversion.unit?(:inch)
     assert @conversion.unit?("m")
+    assert @conversion.unit?("M")
     refute @conversion.unit?("in")
     refute @conversion.unit?(:yard)
+  end
+
+  test "#unit? takes into account case_sensitive flag" do
+    @conversion.set_base :m, case_sensitive: true
+    @conversion.add :inch, aliases: [:in], value: "0.0254 meter", case_sensitive: true
+
+    assert @conversion.unit?(:inch)
+    assert @conversion.unit?("m")
+    refute @conversion.unit?("M")
+    refute @conversion.unit?("in")
   end
 
   test "#unit_or_alias? checks if the unit is part of the units but not aliases" do
@@ -76,8 +87,19 @@ class Measured::ConversionTest < ActiveSupport::TestCase
 
     assert @conversion.unit_or_alias?(:inch)
     assert @conversion.unit_or_alias?("m")
+    assert @conversion.unit_or_alias?(:IN)
     assert @conversion.unit_or_alias?("in")
     refute @conversion.unit_or_alias?(:yard)
+  end
+
+  test "#unit_or_alias? takes into account case_sensitive flag" do
+    @conversion.set_base :m, case_sensitive: true
+    @conversion.add :inch, aliases: [:in], value: "0.0254 meter", case_sensitive: true
+
+    assert @conversion.unit_or_alias?(:inch)
+    assert @conversion.unit_or_alias?("m")
+    refute @conversion.unit_or_alias?(:M)
+    refute @conversion.unit_or_alias?("IN")
   end
 
   test "#to_unit_name converts a unit name to its base unit" do

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -13,6 +13,53 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal ["cake", "pie", "sweets"], Measured::Unit.new(:pie, aliases: ["cake", :sweets]).names
   end
 
+  test "case_sensitive flag default to false" do
+    assert_equal false, @unit.case_sensitive
+  end
+
+  test "#name_eql?" do
+    assert_equal true, @unit.name_eql?("pIe")
+    assert_equal false, @unit.name_eql?("pastry")
+  end
+
+  test "#names_include?" do
+    unit = Measured::Unit.new(:pie, aliases:["cake", "tart"])
+    assert_equal true, unit.names_include?("pie")
+    assert_equal true, unit.names_include?("caKe")
+    assert_equal true, unit.names_include?("taRt")
+    assert_equal false, unit.names_include?("pastry")
+  end
+
+  test "case_sensitive flag set to false" do
+    assert_equal false, Measured::Unit.new(:pie, case_sensitive: false).case_sensitive
+  end
+
+  test "case_sensitive flag set to true, #name_eql?" do
+    unit = Measured::Unit.new(:pie, case_sensitive: true)
+    assert_equal true, unit.name_eql?("pie")
+    assert_equal false, unit.name_eql?("pIe")
+  end
+
+  test "case_sensitive flag set to true, #names_include?" do
+    unit = Measured::Unit.new(:pie, aliases: ["cake", "tart", "pastry"], case_sensitive: true)
+    assert_equal true, unit.names_include?("cake")
+    assert_equal false, unit.names_include?("tArt")
+  end
+
+  test "#add_alias with string" do
+    unit = Measured::Unit.new(:pie, aliases: ["cake"], value: "10 cake")
+    assert_equal ["cake", "pie"], unit.names
+    unit.add_alias("pastry")
+    assert_equal ["cake", "pastry", "pie"], unit.names
+  end
+
+  test "#add_alias with array" do
+    unit = Measured::Unit.new(:pie, aliases: ["cake"], value: "10 cake")
+    assert_equal ["cake", "pie"], unit.names
+    unit.add_alias(["pastry", "tart", "turnover"])
+    assert_equal ["cake", "pastry", "pie", "tart", "turnover"], unit.names
+  end
+
   test "#initialize parses out the unit and the number part" do
     assert_equal BigDecimal(10), @unit.conversion_amount
     assert_equal "cake", @unit.conversion_unit


### PR DESCRIPTION
Directly related to issue #3 . Implements a case_sensitive flag for each Measured::Unit instance. This flag is taken into account when checking if a unit name or alias already exists. Creates methods #name_eql? and #names_include? in Measured::Unit which allow the delegation of Measured::Conversion unit tests to each unit instance. Also adds an #add_alias method which gives the ability to add additional aliases to preexisting units.