### PR TITLE
Respond to zero? through delegation

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -4,6 +4,8 @@ class Measured::Measurable
 
   attr_reader :unit, :value
 
+  delegate :zero?, to: :value
+
   def initialize(value, unit)
     raise Measured::UnitError, "Unit cannot be blank" if unit.blank?
     raise Measured::UnitError, "Unit #{ unit } does not exist" unless self.class.conversion.unit_or_alias?(unit)

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -156,6 +156,11 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "#<Magic: 1.234 magic_missile>", Magic.new(1.234, :magic_missile).inspect
   end
 
+  test "#zero? delegates to the value" do
+    assert Magic.new(0, :fire).zero?
+    refute Magic.new(2, :fire).zero?
+  end
+
   test "#<=> compares regardless of the unit" do
     assert_equal -1, @magic <=> Magic.new(10, :fire)
     assert_equal 1, @magic <=> Magic.new(9, :magic_missile)


### PR DESCRIPTION
@jonathanmwatson @garethson @RichardBlair @cyprusad 

We should respond to `zero?` on `Measurable` since it doesn't matter what the unit is.

Discussion in another thread about if measured objects should respond to `to_i` and `to_f`. I think it's risky and undesirable for this reason:

```ruby
a = Measured::Length.new(1, :cm)
b = Measured::Length.new(1, :m)
a == b # false
a.to_i == b.to_i # true
```

If you really want to work with the value as an int or float, you should have to explicitly ask for the value. I believe this is correct:

```ruby
> height.to_i
NoMethodError: undefined method 'to_i' for #<Measured::Length: 1.0 cm>
from (pry):10:in '<main>'
> height.value.to_i
=> 1
```

Thoughts?