### PR TITLE
Add dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,18 @@
+name: measured
+
+up:
+  - ruby:
+      version: 2.2.4
+  - bundler
+
+commands:
+  test:
+    syntax:
+      optional: file args...
+    desc: 'run all tests or a specific test file'
+    run: |
+      if [[ $# -eq 0 ]]; then
+        bundle exec rake test
+      else
+        bundle exec ruby -Itest "$@"
+      fi


### PR DESCRIPTION
@jonathankwok @thegedge 
cc @burke

Related to https://github.com/Shopify/measured-rails/pull/23

```
~/source/measured(master ✗) dev up
🦄  activated ruby:2.2.4.
✓ 1/2: Installing Ruby (nothing to do)
┏━━ 🦄  2/2: Running Bundler ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
┃ ✓ install bundler (nothing to do)
┃ bundle install
┃ Fetching gem metadata from https://rubygems.org/..........
┃ Fetching version metadata from https://rubygems.org/..
┃ Resolving dependencies...
┃ Using i18n 0.7.0
┃ Using rake 10.4.2
┃ Using thread_safe 0.3.5
┃ Using coderay 1.1.0
┃ Using metaclass 0.0.4
┃ Using method_source 0.8.2
┃ Using slop 3.6.0
┃ Using bundler 1.11.2
┃ Using json 1.8.3
┃ Using tzinfo 1.2.2
┃ Using mocha 1.1.0
┃ Installing minitest 5.5.1
┃ Installing pry 0.10.1
┃ Installing activesupport 4.2.5
┃ Using measured 1.4.0 from source at `.`
┃ Bundle complete! 5 Gemfile dependencies, 15 gems now installed.
┃ Use `bundle show [gemname]` to see where a bundled gem is installed.
┃ ✓ bundle install: done
┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
🦄  activating ruby 2.2.4
~/source/measured(master ✗) dev test
/opt/rubies/2.2.4/bin/ruby -I"lib:test:lib/**/*" -I"/opt/rubies/2.2.4/lib/ruby/2.2.0" "/opt/rubies/2.2.4/lib/ruby/2.2.0/rake/rake_test_loader.rb" "test/arithmetic_test.rb" "test/case_sensitive_measurable_test.rb" "test/conversion_table_test.rb" "test/conversion_test.rb" "test/measurable_test.rb" "test/unit_error_test.rb" "test/unit_test.rb" "test/units/length_test.rb" "test/units/weight_test.rb"
Run options: --seed 12116

# Running:

.................................................................................................................................................................................................

Finished in 0.053218s, 3626.5925 runs/s, 6614.3034 assertions/s.

193 runs, 352 assertions, 0 failures, 0 errors, 0 skips
```