### PR TITLE
Test with consistent Ruby/Rails versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: ruby
+sudo: false
+cache: bundler
 rvm:
-  - 2.1.0
-install:
-  - gem uninstall bundler
-  - gem install bundler --version '1.8.4'
-  - bundle install
+  - 2.1.8
+  - 2.2.4
+  - 2.3.0
+gemfile:
+  - Gemfile
+  - gemfiles/activesupport-4.2.gemfile
+matrix:
+  exclude:
+    - gemfile: Gemfile
+      rvm: 2.1.8

--- a/gemfiles/activesupport-4.2.gemfile
+++ b/gemfiles/activesupport-4.2.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 4.2'


### PR DESCRIPTION
@jonathankwok @benwah 

Update our Travis builds so that it tests with mainline rails (5.0) by default, but also with 4.2. Matrix that with the same ruby versions used to test `measured-rails`. Skip 2.1.x for rails 5 because they are incompatible.

Aligns with https://github.com/Shopify/measured-rails/pull/24