### PR TITLE
Use module function and do not instantiate table unnecessarily

### DIFF
--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -51,7 +51,7 @@ class Measured::Conversion
   end
 
   def conversion_table
-    @conversion_table ||= Measured::ConversionTable.new(@units).to_h
+    @conversion_table ||= Measured::ConversionTable.build(@units)
   end
 
   private

--- a/test/conversion_table_test.rb
+++ b/test/conversion_table_test.rb
@@ -5,15 +5,11 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
     @unit = Measured::Unit.new(:test)
   end
 
-  test "#initialize accepts a list of units and a base unit" do
-    Measured::ConversionTable.new([@unit])
-  end
-
-  test "#to_h should return a hash for the simple case" do
+  test "#build should return a hash for the simple case" do
     expected = {
       "test" => {"test" => BigDecimal("1")}
     }
 
-    assert_equal expected, Measured::ConversionTable.new([@unit]).to_h
+    assert_equal expected, Measured::ConversionTable.build([@unit])
   end
 end


### PR DESCRIPTION
@thegedge @benwah 

Closes #38

## Problem

Unnecessary to create an instance of the conversion table class to call a single function and throw it away.

## Solution

Use a module function. Trade off is that we have to pass `units` down all the way through in a bunch of places.

In the 2.0 milestone, but doesn't change the interface at all for the 1.x version.