### PR TITLE
Make Measurable and Unit immutable objects

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,6 @@ Convert to return a new measurement:
 Measured::Weight.new("12", "g").convert_to("kg")
 ```
 
-Or convert inline:
-
-```ruby
-Measured::Weight.new("12", "g").convert_to!("kg")
-```
-
 Agnostic to symbols/strings:
 
 ```ruby

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -37,15 +37,6 @@ class Measured::Measurable
     self.class.new(value, new_unit)
   end
 
-  def convert_to!(new_unit)
-    converted = convert_to(new_unit)
-
-    @value = converted.value
-    @unit = converted.unit
-
-    self
-  end
-
   def to_s
     [value.to_f.to_s.gsub(/\.0\Z/, ""), unit].join(" ")
   end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -22,10 +22,6 @@ class Measured::Unit
     case_sensitive ? @names.include?(name_to_compare) : case_insensitive(@names).include?(name_to_compare.downcase)
   end
 
-  def add_alias(aliases)
-    @names = (@names << aliases).flatten.sort unless aliases.nil? || aliases.empty?
-  end
-
   def to_s
     if conversion_string
       "#{ @name } (#{ conversion_string })"

--- a/test/case_sensitive_measurable_test.rb
+++ b/test/case_sensitive_measurable_test.rb
@@ -144,16 +144,6 @@ class Measured::CaseSensitiveMeasurableTest < ActiveSupport::TestCase
     assert_equal converted.object_id, @magic.object_id
   end
 
-  test "#convert_to! replaces the existing object with a new version in the new unit" do
-    converted = @magic.convert_to!(:arcane)
-
-    assert_equal converted, @magic
-    assert_equal BigDecimal(1), @magic.value
-    assert_equal "arcane", @magic.unit
-    assert_equal BigDecimal(1), converted.value
-    assert_equal "arcane", converted.unit
-  end
-
   test "#to_s outputs the number and the unit" do
     assert_equal "10 fireball", CaseSensitiveMagic.new(10, :fire).to_s
     assert_equal "1.234 magic_missile", CaseSensitiveMagic.new("1.234", :magic_missile).to_s

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -136,16 +136,6 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal converted.object_id, @magic.object_id
   end
 
-  test "#convert_to! replaces the existing object with a new version in the new unit" do
-    converted = @magic.convert_to!(:arcane)
-
-    assert_equal converted, @magic
-    assert_equal BigDecimal(1), @magic.value
-    assert_equal "arcane", @magic.unit
-    assert_equal BigDecimal(1), converted.value
-    assert_equal "arcane", converted.unit
-  end
-
   test "#to_s outputs the number and the unit" do
     assert_equal "10 fireball", Magic.new(10, :fire).to_s
     assert_equal "1.234 magic_missile", Magic.new("1.234", :magic_missile).to_s

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -49,34 +49,6 @@ class Measured::UnitTest < ActiveSupport::TestCase
     refute unit.names_include?("")
   end
 
-  test "#add_alias with string" do
-    unit = Measured::Unit.new(:pie, aliases: ["cake"], value: "10 cake")
-    assert_equal ["cake", "pie"], unit.names
-    unit.add_alias("pastry")
-    assert_equal ["cake", "pastry", "pie"], unit.names
-  end
-
-  test "#add_alias with array" do
-    unit = Measured::Unit.new(:pie, aliases: ["cake"], value: "10 cake")
-    assert_equal ["cake", "pie"], unit.names
-    unit.add_alias(["pastry", "tart", "turnover"])
-    assert_equal ["cake", "pastry", "pie", "tart", "turnover"], unit.names
-  end
-
-  test "#add_alias with nil" do
-    unit = Measured::Unit.new(:pie, aliases: ["cake"], value: "10 cake")
-    assert_equal ["cake", "pie"], unit.names
-    unit.add_alias(nil)
-    assert_equal ["cake", "pie"], unit.names
-  end
-
-  test "#add_alias with empty string" do
-    unit = Measured::Unit.new(:pie, aliases: ["cake"], value: "10 cake")
-    assert_equal ["cake", "pie"], unit.names
-    unit.add_alias("")
-    assert_equal ["cake", "pie"], unit.names
-  end
-
   test "#initialize parses out the unit and the number part" do
     assert_equal BigDecimal(10), @unit.conversion_amount
     assert_equal "cake", @unit.conversion_unit


### PR DESCRIPTION
Immutability will allow us to more easily introduce certain performance optimizations (e.g., https://github.com/Shopify/measured/pull/29), and makes these classes easier to understand and reason about.

Closes https://github.com/Shopify/measured/issues/30
Closes https://github.com/Shopify/measured/issues/37

@kmcphillips @benwah 