### PR TITLE
Explicitly support 4.2 and up only

### DIFF
--- a/measured.gemspec
+++ b/measured.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 4.0"
+  spec.add_runtime_dependency "activesupport", ">= 4.2"
 
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.5.1"


### PR DESCRIPTION
@benwah @thegedge 

Closes #41

We only run tests on Rails 4.2 and up, and those are the only currently supported versions of Rails.