### PR TITLE
Have Measurable inherit from Numeric

### DIFF
--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -18,7 +18,7 @@ module Measured::Arithmetic
   def coerce(other)
     case other
     when self.class
-      [other.convert_to(self.unit), self]
+      [other, self]
     when Numeric
       [self.class.new(other, self.unit), self]
     else
@@ -34,6 +34,6 @@ module Measured::Arithmetic
 
   def arithmetic_operation(other, operator)
     other, _ = coerce(other)
-    self.class.new(self.value.public_send(operator, other.value), self.unit)
+    self.class.new(self.value.public_send(operator, other.convert_to(self.unit).value), self.unit)
   end
 end

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -15,23 +15,25 @@ module Measured::Arithmetic
     arithmetic_operation(other, :/)
   end
 
-  def -@
-    self.class.new(-self.value, self.unit)
+  def coerce(other)
+    case other
+    when self.class
+      [other.convert_to(self.unit), self]
+    when Numeric
+      [self.class.new(other, self.unit), self]
+    else
+      raise TypeError, "Cannot coerce #{other.class} to #{self.class}"
+    end
   end
 
-  def coerce(other)
-    [self, other]
+  def to_i
+    raise TypeError, "#{self.class} cannot be converted to an integer"
   end
 
   private
 
   def arithmetic_operation(other, operator)
-    if other.is_a?(self.class)
-      self.class.new(self.value.send(operator, other.convert_to(self.unit).value), self.unit)
-    elsif other.is_a?(Numeric)
-      self.class.new(self.value.send(operator, other), self.unit)
-    else
-      raise TypeError, "Invalid operation #{ operator } between #{ self.class } to #{ other.class }"
-    end
+    other, _ = coerce(other)
+    self.class.new(self.value.public_send(operator, other.value), self.unit)
   end
 end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -1,10 +1,7 @@
-class Measured::Measurable
-  include Comparable
+class Measured::Measurable < Numeric
   include Measured::Arithmetic
 
   attr_reader :unit, :value
-
-  delegate :zero?, to: :value
 
   def initialize(value, unit)
     raise Measured::UnitError, "Unit cannot be blank" if unit.blank?
@@ -46,26 +43,13 @@ class Measured::Measurable
   end
 
   def <=>(other)
-    if other.is_a?(self.class)
-      other_converted = other.convert_to(unit)
-      value <=> other_converted.value
-    elsif other == 0
-      other_converted = self.class.new(0, unit)
-      value <=> other_converted.value
+    case other
+    when self.class
+      value <=> other.convert_to(unit).value
+    when 0
+      value <=> 0
     end
   end
-
-  def ==(other)
-    if other.is_a?(self.class)
-      other_converted = other.convert_to(unit)
-      value == other_converted.value
-    elsif other == 0
-      other_converted = self.class.new(0, unit)
-      value == other_converted.value
-    end
-  end
-
-  alias_method :eql?, :==
 
   class << self
 

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -44,7 +44,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
 
   test "#- should subtract a number from the value" do
     assert_equal Magic.new(-1, :magic_missile), @two - 3
-    assert_equal Magic.new(1, :magic_missile), 2 - @three
+    assert_equal Magic.new(-1, :magic_missile), 2 - @three
   end
 
   test "#- should raise if different unit system" do
@@ -104,7 +104,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
 
   test "#/ should divide a number to the value" do
     assert_equal Magic.new("0.5", :magic_missile), @two / 4
-    assert_equal Magic.new(2, :magic_missile), 2 / @four
+    assert_equal Magic.new(0.5, :magic_missile), 2 / @four
   end
 
   test "#/ should raise if different unit system" do

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -130,4 +130,19 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
   test "#-@ returns the negative version" do
     assert_equal Magic.new(-2, :magic_missile), -@two
   end
+
+  test "#coerce should return other as-is when same class" do
+    assert_equal [@two, @three], @three.coerce(@two)
+  end
+
+  test "#coerce should return Fixnum as self's class and same unit" do
+    expected = Magic.new(2, :magic_missile)
+    assert_equal [expected, @three], @three.coerce(2)
+  end
+
+  test "#coerce should raise TypeError when other cannot be coerced" do
+    assert_raises TypeError do
+      @two.coerce(Object.new)
+    end
+  end
 end


### PR DESCRIPTION
Closes https://github.com/Shopify/measured/issues/31

- Gives us some useful numerical operations (e.g., `positive?`, `abs`)
- Allows `Measurable`s to be used in any context where `Numeric` objects are expected.

@kmcphillips @jonathankwok 