### PR TITLE
Don't allow Numeric usage in operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ gem 'measured'
 
 Or stand alone:
 
-    $ gem install measured
+```
+$ gem install measured
+```
 
 ## Usage
 
@@ -42,19 +44,6 @@ Seamlessly handles aliases:
 
 ```ruby
 Measured::Weight.new(12, :oz) == Measured::Weight.new("12", :ounce)
-```
-
-Comparison with zero works without the need to specify units, useful for validations:
-
-```ruby
-Measured::Weight.new(0.001, :kg) > 0
-> true
-
-Measured::Length.new(-1, :m) < 0
-> true
-
-Measured::Weight.new(0, :oz) == 0
-> true
 ```
 
 Raises on unknown units:
@@ -85,13 +74,6 @@ In cases of differing units, the left hand side takes precedence:
 ```ruby
 Measured::Weight.new(1000, :g) + Measured::Weight.new(1, :kg)
 > #<Measured::Weight 2000 g>
-```
-
-Also perform mathematical operations against `Numeric` things:
-
-```ruby
-Measured::Weight.new(3, :g) * 2
-> #<Measured::Weight 6 g>
 ```
 
 Converts units only as needed for equality comparison:

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -15,12 +15,13 @@ module Measured::Arithmetic
     arithmetic_operation(other, :/)
   end
 
+  def -@
+    self.class.new(-self.value, self.unit)
+  end
+
   def coerce(other)
-    case other
-    when self.class
+    if other.is_a?(self.class)
       [other, self]
-    when Numeric
-      [self.class.new(other, self.unit), self]
     else
       raise TypeError, "Cannot coerce #{other.class} to #{self.class}"
     end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -43,11 +43,10 @@ class Measured::Measurable < Numeric
   end
 
   def <=>(other)
-    case other
-    when self.class
+    if other.is_a?(self.class)
       value <=> other.convert_to(unit).value
-    when 0
-      value <=> 0
+    else
+      nil
     end
   end
 

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -131,6 +131,16 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(-2, :magic_missile), -@two
   end
 
+  test "arithmetic operations favours unit of left" do
+    left = Magic.new(1, :arcane)
+    right = Magic.new(1, :magic_missile)
+
+    assert_equal "arcane", (left + right).unit
+    assert_equal "arcane", (left - right).unit
+    assert_equal "arcane", (left * right).unit
+    assert_equal "arcane", (left / right).unit
+  end
+
   test "#coerce should return other as-is when same class" do
     assert_equal [@two, @three], @three.coerce(@two)
   end

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -12,9 +12,9 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(5, :magic_missile), @three + @two
   end
 
-  test "#+ should add a number to the value" do
-    assert_equal Magic.new(5, :magic_missile), @two + 3
-    assert_equal Magic.new(5, :magic_missile), 2 + @three
+  test "#+ shouldn't add with a Fixnum" do
+    assert_raises(TypeError) { @two + 3 }
+    assert_raises(TypeError) { 2 + @three }
   end
 
   test "#+ should raise if different unit system" do
@@ -42,9 +42,9 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(1, :magic_missile), @three - @two
   end
 
-  test "#- should subtract a number from the value" do
-    assert_equal Magic.new(-1, :magic_missile), @two - 3
-    assert_equal Magic.new(-1, :magic_missile), 2 - @three
+  test "#- shouldn't subtract with a Fixnum" do
+    assert_raises(TypeError) { @two - 3 }
+    assert_raises(TypeError) { 2 - @three }
   end
 
   test "#- should raise if different unit system" do
@@ -72,9 +72,9 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(6, :magic_missile), @three * @two
   end
 
-  test "#* should multiply a number to the value" do
-    assert_equal Magic.new(6, :magic_missile), @two * 3
-    assert_equal Magic.new(6, :magic_missile), 2 * @three
+  test "#* shouldn't multiply with a Fixnum" do
+    assert_raises(TypeError) { @two * 3 }
+    assert_raises(TypeError) { 2 * @three }
   end
 
   test "#* should raise if different unit system" do
@@ -102,9 +102,9 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(2, :magic_missile), @four / @two
   end
 
-  test "#/ should divide a number to the value" do
-    assert_equal Magic.new("0.5", :magic_missile), @two / 4
-    assert_equal Magic.new(0.5, :magic_missile), 2 / @four
+  test "#/ shouldn't divide with a Fixnum" do
+    assert_raises(TypeError) { @two / 4 }
+    assert_raises(TypeError) { 2 / @four }
   end
 
   test "#/ should raise if different unit system" do
@@ -135,14 +135,9 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal [@two, @three], @three.coerce(@two)
   end
 
-  test "#coerce should return Fixnum as self's class and same unit" do
-    expected = Magic.new(2, :magic_missile)
-    assert_equal [expected, @three], @three.coerce(2)
-  end
-
   test "#coerce should raise TypeError when other cannot be coerced" do
-    assert_raises TypeError do
-      @two.coerce(Object.new)
-    end
+    assert_raises(TypeError) { @two.coerce(2) }
+    assert_raises(TypeError) { @three.coerce(5.2) }
+    assert_raises(TypeError) { @four.coerce(Object.new) }
   end
 end


### PR DESCRIPTION
## Problem
As mentioned in https://github.com/Shopify/measured/issues/46, adding/subtracting `Numeric` values to/from a `Measurable` is confusing, since no unit is specified and we'd rather not assume it's in the same unit as the `Measurable`. We'd like to allow scaling the `Measurable` by a scalar, but can't do so without allowing addition too.

## Solution
Given we want to avoid confusion, we'll remove the ability to coerce `Numeric` values into `Measurable`s, and require someone to manually do that conversion. This may lead to more verbose code, but hopefully things like https://github.com/Shopify/measured/issues/39 will reduce the verboseness.

In a follow up PR I'll also add a `scale` method to allow multiplying a `Measurable` by a scalar.

@kmcphillips @jonathankwok 