### PR TITLE
Split unit_for into a bang and non-bang version

### DIFF
--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -47,10 +47,12 @@ class Measured::Conversion
   end
 
   def unit_for(name)
-    unit = @units.find { |unit| unit.names_include?(name, case_sensitive: @case_sensitive) }
+    @units.find { |unit| unit.names_include?(name, case_sensitive: @case_sensitive) }
   end
 
   def unit_for!(name)
-    unit_for(name) or raise Measured::UnitError, "Cannot find unit for #{name}"
+    unit = unit_for(name)
+    raise Measured::UnitError, "Cannot find unit for #{name}" unless unit
+    unit
   end
 end

--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -27,12 +27,12 @@ class Measured::Conversion
   end
 
   def to_unit_name(name)
-    unit_for(name).name
+    unit_for!(name).name
   end
 
   def convert(value, from:, to:)
-    from_unit = unit_for(from)
-    to_unit = unit_for(to)
+    from_unit = unit_for!(from)
+    to_unit = unit_for!(to)
     conversion = conversion_table[from][to]
 
     raise Measured::UnitError, "Cannot find conversion entry from #{from} to #{to}" unless conversion
@@ -48,6 +48,9 @@ class Measured::Conversion
 
   def unit_for(name)
     unit = @units.find { |unit| unit.names_include?(name, case_sensitive: @case_sensitive) }
-    unit or raise Measured::UnitError, "Cannot find unit for #{name}"
+  end
+
+  def unit_for!(name)
+    unit_for(name) or raise Measured::UnitError, "Cannot find unit for #{name}"
   end
 end


### PR DESCRIPTION
From @nicolaslupien's [comment](https://github.com/Shopify/measured/pull/51#discussion_r92469298), we should suffix this function with an exclamation mark, since it raises. To keep things super tight, I've also went ahead with his suggestion to split the function. Unit tests already exist to check if `to_unit_name` and `convert` raise.