### PR TITLE
Separate case insensitive concerns into separate class

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,9 +171,7 @@ end
 By default all names and aliases are case insensitive. If you would like to create a new unit with names and aliases that are case sensitive, specify the case sensitive flag when building your unit:
 
 ```ruby
-Measured::Thing = Measured.build do
-  case_sensitive true
-
+Measured::Thing = Measured.build(case_sensitive: true) do
   base :base_unit, aliases: [:bu]
 end
 ```

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -6,8 +6,8 @@ module Measured
   class UnitError < StandardError ; end
 
   class << self
-    def build(&block)
-      builder = ConversionBuilder.new
+    def build(**kwargs, &block)
+      builder = ConversionBuilder.new(**kwargs)
       builder.instance_eval(&block)
 
       Class.new(Measurable) do
@@ -39,6 +39,7 @@ end
 
 require "measured/arithmetic"
 require "measured/unit"
+require "measured/case_insensitive_unit"
 require "measured/conversion"
 require "measured/conversion_builder"
 require "measured/conversion_table"

--- a/lib/measured/case_insensitive_unit.rb
+++ b/lib/measured/case_insensitive_unit.rb
@@ -1,0 +1,13 @@
+class Measured::CaseInsensitiveUnit < Measured::Unit
+  def initialize(name, aliases: [], value: nil)
+    super(name.to_s.downcase, aliases: aliases.map(&:to_s).map!(&:downcase), value: value)
+  end
+
+  def name_eql?(name_to_compare)
+    super(name_to_compare.to_s.downcase)
+  end
+
+  def names_include?(name_to_compare)
+    super(name_to_compare.to_s.downcase)
+  end
+end

--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -1,14 +1,13 @@
 class Measured::Conversion
   ARBITRARY_CONVERSION_PRECISION = 20
 
-  def initialize(base_unit, units, case_sensitive: false)
-    @case_sensitive = case_sensitive
+  attr_reader :base_unit, :units
+
+  def initialize(base_unit, units)
     @base_unit = base_unit
     @units = units.dup
     @units << @base_unit
   end
-
-  attr_reader :base_unit, :units
 
   def unit_names_with_aliases
     @unit_names_with_aliases ||= @units.flat_map(&:names).sort
@@ -19,11 +18,11 @@ class Measured::Conversion
   end
 
   def unit_or_alias?(name)
-    @units.any? { |unit| unit.names_include?(name, case_sensitive: @case_sensitive) }
+    @units.any? { |unit| unit.names_include?(name) }
   end
 
   def unit?(name)
-    @units.any? { |unit| unit.name_eql?(name, case_sensitive: @case_sensitive) }
+    @units.any? { |unit| unit.name_eql?(name) }
   end
 
   def to_unit_name(name)
@@ -37,7 +36,7 @@ class Measured::Conversion
 
     raise Measured::UnitError, "Cannot find conversion entry from #{from} to #{to}" unless conversion
 
-    BigDecimal(value.to_r * conversion,ARBITRARY_CONVERSION_PRECISION)
+    BigDecimal(value.to_r * conversion, ARBITRARY_CONVERSION_PRECISION)
   end
 
   private
@@ -47,7 +46,7 @@ class Measured::Conversion
   end
 
   def unit_for(name)
-    @units.find { |unit| unit.names_include?(name, case_sensitive: @case_sensitive) }
+    @units.find { |unit| unit.names_include?(name) }
   end
 
   def unit_for!(name)

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -1,25 +1,22 @@
 class Measured::Unit
   include Comparable
 
+  attr_reader :name, :names, :conversion_amount, :conversion_unit
+
   def initialize(name, aliases: [], value: nil)
     @name = name.to_s
-    @names = ([@name] + aliases.map{|n| n.to_s }).sort
-
+    @names = ([@name] + aliases.map(&:to_s)).sort
     @conversion_amount, @conversion_unit = parse_value(value) if value
   end
 
-  attr_reader :name, :names, :conversion_amount, :conversion_unit
-
-  def name_eql?(name_to_compare, case_sensitive: false)
+  def name_eql?(name_to_compare)
     return false unless name_to_compare.present?
-    name_to_compare = name_to_compare.to_s
-    case_sensitive ? @name.eql?(name_to_compare) : case_insensitive(@name).include?(name_to_compare.downcase)
+    @name.eql?(name_to_compare.to_s)
   end
 
-  def names_include?(name_to_compare, case_sensitive: false)
+  def names_include?(name_to_compare)
     return false unless name_to_compare.present?
-    name_to_compare = name_to_compare.to_s
-    case_sensitive ? @names.include?(name_to_compare) : case_insensitive(@names).include?(name_to_compare.downcase)
+    @names.include?(name_to_compare.to_s)
   end
 
   def to_s
@@ -51,10 +48,6 @@ class Measured::Unit
   end
 
   private
-
-  def case_insensitive(comparison)
-    [comparison].flatten.map(&:downcase)
-  end
 
   def conversion_string
     "#{ conversion_amount } #{ conversion_unit }" if @conversion_amount || @conversion_unit

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -1,0 +1,103 @@
+require "test_helper"
+
+class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
+  setup do
+    @unit = Measured::CaseInsensitiveUnit.new(:Pie, value: "10 Cake")
+    @unit_with_aliases = Measured::CaseInsensitiveUnit.new(:Pie, aliases: ["Cake", "Tart"])
+  end
+
+  test "#initialize converts the name to a downcased string" do
+    assert_equal "pie", @unit.name
+  end
+
+  test "#initialize converts aliases to strings and makes a list of sorted, downcased names which includes the base" do
+    assert_equal %w(cake pie sweets), Measured::CaseInsensitiveUnit.new(:pie, aliases: ["Cake", :Sweets]).names
+  end
+
+  test "#name_eql? true for valid names" do
+    assert @unit.name_eql?("Pie")
+    assert @unit.name_eql?("pie")
+    refute @unit.name_eql?("pastry")
+  end
+
+  test "#name_eql? false with empty string" do
+    refute @unit.name_eql?("")
+  end
+
+  test "#names_include? is case insensitive" do
+    assert @unit_with_aliases.names_include?("Pie")
+    assert @unit_with_aliases.names_include?("Cake")
+    assert @unit_with_aliases.names_include?("Tart")
+    assert @unit_with_aliases.names_include?("pie")
+    assert @unit_with_aliases.names_include?("cake")
+    assert @unit_with_aliases.names_include?("tart")
+    refute @unit_with_aliases.names_include?("pastry")
+  end
+
+  test "#names_include? false with empty string" do
+    refute @unit_with_aliases.names_include?("")
+  end
+
+  test "#initialize parses out the unit and the number part" do
+    assert_equal BigDecimal(10), @unit.conversion_amount
+    assert_equal "Cake", @unit.conversion_unit
+
+    unit = Measured::CaseInsensitiveUnit.new(:pie, value: "5.5 sweets")
+    assert_equal BigDecimal("5.5"), unit.conversion_amount
+    assert_equal "sweets", unit.conversion_unit
+  end
+
+  test "#initialize raises if the format of the value is incorrect" do
+    assert_raises Measured::UnitError do
+      Measured::CaseInsensitiveUnit.new(:pie, value: "hello")
+    end
+
+    assert_raises Measured::UnitError do
+      Measured::CaseInsensitiveUnit.new(:pie, value: "pie is delicious")
+    end
+
+    assert_raises Measured::UnitError do
+      Measured::CaseInsensitiveUnit.new(:pie, value: "123456")
+    end
+  end
+
+  test "#to_s returns an expected string" do
+    assert_equal "pie", Measured::CaseInsensitiveUnit.new(:pie).to_s
+    assert_equal "pie (1/2 sweet)", Measured::CaseInsensitiveUnit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).to_s
+  end
+
+  test "#inspect returns an expected string" do
+    assert_equal "#<Measured::Unit: pie (pie) >", Measured::CaseInsensitiveUnit.new(:pie).inspect
+    assert_equal "#<Measured::Unit: pie (cake, pie) 1/2 sweet>", Measured::CaseInsensitiveUnit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).inspect
+  end
+
+  test "includes Comparable mixin" do
+    assert Measured::Unit.ancestors.include?(Comparable)
+  end
+
+  test "#<=> compares non-Unit classes against name" do
+    assert_equal 1, @unit <=> "pap"
+    assert_equal -1, @unit <=> "pop"
+  end
+
+  test "#<=> is 0 for Unit instances that should be equivalent" do
+    assert_equal 0, @unit <=> Measured::CaseInsensitiveUnit.new(:Pie, value: "10 cake")
+    assert_equal 0, @unit <=> Measured::CaseInsensitiveUnit.new("Pie", value: "10 cake")
+    assert_equal 0, @unit <=> Measured::CaseInsensitiveUnit.new("Pie", value: [10, :cake])
+  end
+
+  test "#<=> is 1 for " do
+    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pies, value: "10 cake")
+    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new("pie", aliases: ["pies"], value: "10 cake")
+    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pie, value: [11, :cake])
+  end
+
+  test "#inverse_conversion_amount returns 1/amount for BigDecimal" do
+    assert_equal BigDecimal(1) / 10, @unit.inverse_conversion_amount
+  end
+
+  test "#inverse_conversion_amount swaps the numerator and denominator for Rational" do
+    unit = Measured::CaseInsensitiveUnit.new(:pie, value: [Rational(3, 7), "cake"])
+    assert_equal Rational(7, 3), unit.inverse_conversion_amount
+  end
+end

--- a/test/conversion_builder_test.rb
+++ b/test/conversion_builder_test.rb
@@ -42,7 +42,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
     end
 
     assert_raises Measured::UnitError do
-      Measured.build do
+      Measured.build(case_sensitive: true) do
         base :m
         unit :in, aliases: [:inch], value: "0.0254 m"
         unit :inch, aliases: [:thing], value: "123 m"
@@ -50,8 +50,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
     end
 
     assert_raises Measured::UnitError do
-      Measured.build do
-        case_sensitive false
+      Measured.build(case_sensitive: false) do
         base :normal
         unit :bold, aliases: [:strong], value: "10 normal"
         unit :bolder, aliases: [:BOLD], value: "100 normal"
@@ -60,8 +59,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
   end
 
   test "#case_sensitive true produces a case-sensitive conversion" do
-    measurable = Measured.build do
-      case_sensitive true
+    measurable = Measured.build(case_sensitive: true) do
       base :normal
       unit :bold, value: "10 normal"
       unit :BOLD, value: "100 normal"
@@ -71,7 +69,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
   end
 
   test "case-insensitive conversion is produced by defaul" do
-    measurable = Measured.build do
+    measurable = Measured.build(case_sensitive: false) do
       base :normal
       unit :bold, value: "10 normal"
       unit :bolder, value: "100 normal"

--- a/test/conversion_test.rb
+++ b/test/conversion_test.rb
@@ -2,14 +2,13 @@ require "test_helper"
 
 class Measured::ConversionTest < ActiveSupport::TestCase
   setup do
-    @base = Measured::Unit.new(:m)
+    @base = Measured::CaseInsensitiveUnit.new(:m)
     @units = [
-      Measured::Unit.new(:in, aliases: [:inch], value: "0.0254 m"),
-      Measured::Unit.new(:ft, aliases: [:feet, :foot], value: "0.3048 m"),
+      Measured::CaseInsensitiveUnit.new(:in, aliases: [:inch], value: "0.0254 m"),
+      Measured::CaseInsensitiveUnit.new(:ft, aliases: [:feet, :foot], value: "0.3048 m"),
     ]
 
     @conversion = Measured::Conversion.new(@base, @units)
-    @case_sensitive_conversion = Measured::Conversion.new(@base, @units, case_sensitive: true)
   end
 
   test "#unit_names_with_aliases lists all allowed unit names" do
@@ -28,13 +27,6 @@ class Measured::ConversionTest < ActiveSupport::TestCase
     refute @conversion.unit?(:yard)
   end
 
-  test "#unit? takes into account case_sensitive flag" do
-    assert @case_sensitive_conversion.unit?(:in)
-    assert @case_sensitive_conversion.unit?("m")
-    refute @case_sensitive_conversion.unit?("M")
-    refute @case_sensitive_conversion.unit?("inch")
-  end
-
   test "#unit? with blank and nil arguments" do
     refute @conversion.unit?("")
     refute @conversion.unit?(nil)
@@ -46,13 +38,6 @@ class Measured::ConversionTest < ActiveSupport::TestCase
     assert @conversion.unit_or_alias?(:IN)
     assert @conversion.unit_or_alias?("in")
     refute @conversion.unit_or_alias?(:yard)
-  end
-
-  test "#unit_or_alias? takes into account case_sensitive flag" do
-    assert @case_sensitive_conversion.unit_or_alias?(:inch)
-    assert @case_sensitive_conversion.unit_or_alias?("m")
-    refute @case_sensitive_conversion.unit_or_alias?(:M)
-    refute @case_sensitive_conversion.unit_or_alias?("IN")
   end
 
   test "#unit_or_alias? with blank and nil arguments" do

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -10,44 +10,28 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal "Pie", @unit.name
   end
 
-  test "#initialize converts aliases to strings and makes a list of names which includes the base" do
-    assert_equal ["cake", "pie", "sweets"], Measured::Unit.new(:pie, aliases: ["cake", :sweets]).names
+  test "#initialize converts aliases to strings and makes a list of sorted names which includes the base" do
+    assert_equal %w(Cake pie sweets), Measured::Unit.new(:pie, aliases: ["Cake", :sweets]).names
   end
 
-  test "#name_eql? true for valid names when case_sensitive: true" do
-    assert @unit.name_eql?("Pie", case_sensitive: true)
-    refute @unit.name_eql?("pie", case_sensitive: true)
-    refute @unit.name_eql?("pastry", case_sensitive: true)
-  end
-
-  test "#name_eql? true for valid names when case_sensitive: false" do
-    assert @unit.name_eql?("Pie", case_sensitive: false)
-    assert @unit.name_eql?("pie", case_sensitive: false)
-    refute @unit.name_eql?("pastry", case_sensitive: false)
+  test "#name_eql? true for valid names" do
+    assert @unit.name_eql?("Pie")
+    refute @unit.name_eql?("pie")
+    refute @unit.name_eql?("pastry")
   end
 
   test "#name_eql? false with empty string" do
     refute @unit.name_eql?("")
   end
 
-  test "#names_include? is case insensitive when initialized with case_sensitive: false" do
-    assert @unit_with_aliases.names_include?("Pie", case_sensitive: false)
-    assert @unit_with_aliases.names_include?("Cake", case_sensitive: false)
-    assert @unit_with_aliases.names_include?("Tart", case_sensitive: false)
-    assert @unit_with_aliases.names_include?("pie", case_sensitive: false)
-    assert @unit_with_aliases.names_include?("cake", case_sensitive: false)
-    assert @unit_with_aliases.names_include?("tart", case_sensitive: false)
-    refute @unit_with_aliases.names_include?("pastry", case_sensitive: false)
-  end
-
-  test "#names_include? is case sensitive when initialized with case_sensitive: true" do
-    assert @unit_with_aliases.names_include?("Pie", case_sensitive: true)
-    assert @unit_with_aliases.names_include?("Cake", case_sensitive: true)
-    assert @unit_with_aliases.names_include?("Tart", case_sensitive: true)
-    refute @unit_with_aliases.names_include?("pie", case_sensitive: true)
-    refute @unit_with_aliases.names_include?("cake", case_sensitive: true)
-    refute @unit_with_aliases.names_include?("tart", case_sensitive: true)
-    refute @unit_with_aliases.names_include?("pastry", case_sensitive: true)
+  test "#names_include? is case sensitive" do
+    assert @unit_with_aliases.names_include?("Pie")
+    assert @unit_with_aliases.names_include?("Cake")
+    assert @unit_with_aliases.names_include?("Tart")
+    refute @unit_with_aliases.names_include?("pie")
+    refute @unit_with_aliases.names_include?("cake")
+    refute @unit_with_aliases.names_include?("tart")
+    refute @unit_with_aliases.names_include?("pastry")
   end
 
   test "#names_include? false with empty string" do


### PR DESCRIPTION
## Problem
Right now, you have to pay some cost for case insensitive checks, even if you don't need them.

## Solution
Remove this cost by creating a separate class to do `downcase`-ing. If a case-insensitive unit system is built, then this cost will be payed. If a case-sensitive unit system is built, no additional costs are paid.

Most of this PR is just a copy of `unit_test.rb`, with assertions adjusted for case insensitivity. rspec shared examples would be 👌 