### PR TITLE
Replace Fixnum/Bignum with Integer

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -10,7 +10,7 @@ class Measured::Measurable < Numeric
     @value = case value
     when Float
       BigDecimal(value, Float::DIG+1)
-    when Fixnum, Bignum
+    when Integer
       BigDecimal(value)
     when NilClass
       raise Measured::UnitError, "Unit value cannot be nil"

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -12,7 +12,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(5, :magic_missile), @three + @two
   end
 
-  test "#+ shouldn't add with a Fixnum" do
+  test "#+ shouldn't add with a Integer" do
     assert_raises(TypeError) { @two + 3 }
     assert_raises(TypeError) { 2 + @three }
   end
@@ -42,7 +42,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(1, :magic_missile), @three - @two
   end
 
-  test "#- shouldn't subtract with a Fixnum" do
+  test "#- shouldn't subtract with a Integer" do
     assert_raises(TypeError) { @two - 3 }
     assert_raises(TypeError) { 2 - @three }
   end
@@ -72,7 +72,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(6, :magic_missile), @three * @two
   end
 
-  test "#* shouldn't multiply with a Fixnum" do
+  test "#* shouldn't multiply with a Integer" do
     assert_raises(TypeError) { @two * 3 }
     assert_raises(TypeError) { 2 * @three }
   end
@@ -102,7 +102,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal Magic.new(2, :magic_missile), @four / @two
   end
 
-  test "#/ shouldn't divide with a Fixnum" do
+  test "#/ shouldn't divide with a Integer" do
     assert_raises(TypeError) { @two / 4 }
     assert_raises(TypeError) { 2 / @four }
   end


### PR DESCRIPTION
Ruby 2.4 unified `Fixnum` and `Bignum` under `Integer` [1], both of which were subclasses of `Integer` pre-2.4.

One small bonus of this is that a simpler `when` clause means we'll actually be faster. Here's the instructions for just `when Integer`:
```
0006 dup                                                              (   3)
0007 getinlinecache   14, <is:0>
0010 getconstant      :Integer
0012 setinlinecache   <is:0>
0014 checkmatch       2
0016 branchif         45
```
and here are the instructions for `when Fixnum, Bignum`
```
0018 dup                                                              (   5)
0019 getinlinecache   26, <is:1>
0022 getconstant      :Fixnum
0024 setinlinecache   <is:1>
0026 checkmatch       2
0028 branchif         50
0030 dup
0031 getinlinecache   38, <is:2>
0034 getconstant      :Bignum
0036 setinlinecache   <is:2>
0038 checkmatch       2
0040 branchif         50
```

[1] http://blog.bigbinary.com/2016/11/18/ruby-2-4-unifies-fixnum-and-bignum-into-integer.html