### PR TITLE
Remove name_eql? and names_include? from Unit interface

### DIFF
--- a/lib/measured/case_insensitive_conversion.rb
+++ b/lib/measured/case_insensitive_conversion.rb
@@ -1,4 +1,8 @@
 class Measured::CaseInsensitiveConversion < Measured::Conversion
+  def unit?(name)
+    super(name.to_s.downcase)
+  end
+
   protected
 
   def unit_for(name)

--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -23,7 +23,7 @@ class Measured::Conversion
 
   def unit?(name)
     unit = unit_for(name)
-    unit ? unit.name_eql?(name) : false
+    unit ? unit.name == name.to_s : false
   end
 
   def to_unit_name(name)

--- a/lib/measured/conversion_builder.rb
+++ b/lib/measured/conversion_builder.rb
@@ -41,7 +41,7 @@ class Measured::ConversionBuilder
     names = @units.flat_map(&:names)
     names += @base_unit.names if @base_unit
 
-    if names.any? { |name| unit.names_include?(name) }
+    if names.any? { |name| unit.names.include?(name) }
       raise Measured::UnitError, "Unit #{unit.name} has already been added."
     end
   end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -9,16 +9,6 @@ class Measured::Unit
     @conversion_amount, @conversion_unit = parse_value(value) if value
   end
 
-  def name_eql?(name_to_compare)
-    return false unless name_to_compare.present?
-    @name.eql?(name_to_compare.to_s)
-  end
-
-  def names_include?(name_to_compare)
-    return false unless name_to_compare.present?
-    @names.include?(name_to_compare.to_s)
-  end
-
   def to_s
     if conversion_string
       "#{ @name } (#{ conversion_string })"

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -14,30 +14,6 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
     assert_equal %w(cake pie sweets), Measured::CaseInsensitiveUnit.new(:pie, aliases: ["Cake", :Sweets]).names
   end
 
-  test "#name_eql? true for valid names" do
-    assert @unit.name_eql?("Pie")
-    assert @unit.name_eql?("pie")
-    refute @unit.name_eql?("pastry")
-  end
-
-  test "#name_eql? false with empty string" do
-    refute @unit.name_eql?("")
-  end
-
-  test "#names_include? is case insensitive" do
-    assert @unit_with_aliases.names_include?("Pie")
-    assert @unit_with_aliases.names_include?("Cake")
-    assert @unit_with_aliases.names_include?("Tart")
-    assert @unit_with_aliases.names_include?("pie")
-    assert @unit_with_aliases.names_include?("cake")
-    assert @unit_with_aliases.names_include?("tart")
-    refute @unit_with_aliases.names_include?("pastry")
-  end
-
-  test "#names_include? false with empty string" do
-    refute @unit_with_aliases.names_include?("")
-  end
-
   test "#initialize parses out the unit and the number part" do
     assert_equal BigDecimal(10), @unit.conversion_amount
     assert_equal "Cake", @unit.conversion_unit

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -14,30 +14,6 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal %w(Cake pie sweets), Measured::Unit.new(:pie, aliases: ["Cake", :sweets]).names
   end
 
-  test "#name_eql? true for valid names" do
-    assert @unit.name_eql?("Pie")
-    refute @unit.name_eql?("pie")
-    refute @unit.name_eql?("pastry")
-  end
-
-  test "#name_eql? false with empty string" do
-    refute @unit.name_eql?("")
-  end
-
-  test "#names_include? is case sensitive" do
-    assert @unit_with_aliases.names_include?("Pie")
-    assert @unit_with_aliases.names_include?("Cake")
-    assert @unit_with_aliases.names_include?("Tart")
-    refute @unit_with_aliases.names_include?("pie")
-    refute @unit_with_aliases.names_include?("cake")
-    refute @unit_with_aliases.names_include?("tart")
-    refute @unit_with_aliases.names_include?("pastry")
-  end
-
-  test "#names_include? false with empty string" do
-    refute @unit_with_aliases.names_include?("")
-  end
-
   test "#initialize parses out the unit and the number part" do
     assert_equal BigDecimal(10), @unit.conversion_amount
     assert_equal "Cake", @unit.conversion_unit


### PR DESCRIPTION
Simplifying the interface of `Unit`.

This is definitely up for discussion, particularly how far the case sensitivity aspects of measured dig in. A big question is was this confusing before? More specifically, would a user of our library be confused at why there's `name_eql?`, and would it have differed from `unit.name == "something"`?

In general, I'd like to drop the case-sensitive aspects of measured completely, but if we keep them I would like them to be as out of the way as possible. I think the interaction with `Unit` is rare, and in general users aren't manually comparing things but grabbing it for presentation / informational purposes.

Closes https://github.com/Shopify/measured/issues/33