### PR TITLE
Test with ruby 2.4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ cache: bundler
 rvm:
   - 2.1.8
   - 2.2.4
-  - 2.3.0
+  - 2.3.1
+  - 2.4.0
 gemfile:
   - Gemfile
   - gemfiles/activesupport-4.2.gemfile
@@ -12,3 +13,5 @@ matrix:
   exclude:
     - gemfile: Gemfile
       rvm: 2.1.8
+    - gemfile: gemfiles/activesupport-4.2.gemfile
+      rvm: 2.4.0


### PR DESCRIPTION
Include Ruby 2.4.0 in our CI list. Skip Rails 4.2 as there is a JSON version conflict.

Also bump our 2.3 to 2.3.1.

Related to https://github.com/Shopify/measured-rails/pull/33