### PR TITLE
Add #scale method for multiplying by a scalar

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ rescue Measured::UnitError
 end
 ```
 
-Perform addition / sctraction against other units, all represented internally as `BigDecimal`:
+Perform addition / subtraction against other units, all represented internally as `BigDecimal`:
 
 ```ruby
 Measured::Weight.new(1, :g) + Measured::Weight.new(2, :g)

--- a/README.md
+++ b/README.md
@@ -56,16 +56,21 @@ rescue Measured::UnitError
 end
 ```
 
-Perform mathematical operations against other units, all represented internally as `BigDecimal`:
+Perform addition / sctraction against other units, all represented internally as `BigDecimal`:
 
 ```ruby
 Measured::Weight.new(1, :g) + Measured::Weight.new(2, :g)
 > #<Measured::Weight 3 g>
 Measured::Weight.new(2, :g) - Measured::Weight.new(1, :g)
 > #<Measured::Weight 1 g>
-Measured::Weight.new(10, :g) / Measured::Weight.new(2, :g)
+```
+
+Multiplication and division by units is not supported, but the actual value can be scaled by a scalar:
+
+```ruby
+Measured::Weight.new(10, :g).scale(0.5)
 > #<Measured::Weight 5 g>
-Measured::Weight.new(2, :g) * Measured::Weight.new(3, :g)
+Measured::Weight.new(2, :g).scale(3)
 > #<Measured::Weight 6 g>
 ```
 

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -7,16 +7,12 @@ module Measured::Arithmetic
     arithmetic_operation(other, :-)
   end
 
-  def *(other)
-    arithmetic_operation(other, :*)
-  end
-
-  def /(other)
-    arithmetic_operation(other, :/)
-  end
-
   def -@
     self.class.new(-self.value, self.unit)
+  end
+
+  def scale(other)
+    self.class.new(self.value * other, self.unit)
   end
 
   def coerce(other)

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -67,68 +67,13 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     end
   end
 
-  test "#* should multiply together same units" do
-    assert_equal Magic.new(6, :magic_missile), @two * @three
-    assert_equal Magic.new(6, :magic_missile), @three * @two
-  end
-
-  test "#* shouldn't multiply with a Integer" do
-    assert_raises(TypeError) { @two * 3 }
-    assert_raises(TypeError) { 2 * @three }
-  end
-
-  test "#* should raise if different unit system" do
-    assert_raises TypeError do
-      OtherFakeSystem.new(1, :other_fake_base) * @two
-    end
-
-    assert_raises TypeError do
-      @two * OtherFakeSystem.new(1, :other_fake_base)
-    end
-  end
-
-  test "#* should raise if multiplying something nonsense" do
-    assert_raises TypeError do
-      @two * "thing"
-    end
-
-    assert_raises TypeError do
-      "thing" * @two
-    end
-  end
-
-  test "#/ should divide together same units" do
-    assert_equal Magic.new("0.5", :magic_missile), @two / @four
-    assert_equal Magic.new(2, :magic_missile), @four / @two
-  end
-
-  test "#/ shouldn't divide with a Integer" do
-    assert_raises(TypeError) { @two / 4 }
-    assert_raises(TypeError) { 2 / @four }
-  end
-
-  test "#/ should raise if different unit system" do
-    assert_raises TypeError do
-      OtherFakeSystem.new(1, :other_fake_base) / @two
-    end
-
-    assert_raises TypeError do
-      @two / OtherFakeSystem.new(1, :other_fake_base)
-    end
-  end
-
-  test "#/ should raise if dividing something nonsense" do
-    assert_raises TypeError do
-      @two / "thing"
-    end
-
-    assert_raises NoMethodError do
-      "thing" / @two
-    end
-  end
-
   test "#-@ returns the negative version" do
     assert_equal Magic.new(-2, :magic_missile), -@two
+  end
+
+  test "#scale should multiply the value by a given scalar" do
+    assert_equal Magic.new(-2, :magic_missile), @two.scale(-1)
+    assert_equal Magic.new(5, :magic_missile), @two.scale(2.5)
   end
 
   test "arithmetic operations favours unit of left" do
@@ -137,8 +82,6 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
 
     assert_equal "arcane", (left + right).unit
     assert_equal "arcane", (left - right).unit
-    assert_equal "arcane", (left * right).unit
-    assert_equal "arcane", (left / right).unit
   end
 
   test "#coerce should return other as-is when same class" do


### PR DESCRIPTION
From https://github.com/Shopify/measured/issues/46#issuecomment-264977606 and onwards, we want to get rid of multiplication / division on `Measurable` instances because, for example, `1kg · 1kg = 1kg²`. The new way to scale the value of a `Measurable` is via its `#scale` method.

Closes https://github.com/Shopify/measured/issues/46