### PR TITLE
Add support for extending Numerics with #unit methods

### DIFF
--- a/lib/measured/util.rb
+++ b/lib/measured/util.rb
@@ -1,0 +1,24 @@
+module Measured
+  class << self
+    alias_method :old_build, :build
+
+    def build(**kwargs, &block)
+      measurable = old_build(**kwargs, &block)
+      add_extensions(measurable)
+      measurable
+    end
+
+    private
+
+    def add_extensions(measurable)
+      measurable.units_with_aliases.each do |name|
+        Numeric.class_eval do
+          define_method(name) { measurable.new(self, name) }
+        end
+      end
+    end
+  end
+
+  add_extensions(Measured::Length) if defined?(Measured::Length)
+  add_extensions(Measured::Weight) if defined?(Measured::Weight)
+end


### PR DESCRIPTION
Requiring this new file will result in adding extensions to `Numeric` that allows one to more easily create `Measurable` instances. For example:

```ruby
irb(main):001:0> require 'measured/util'
=> true
irb(main):002:0> Magic = Measured.build do
irb(main):003:1*       base :magic_missile, aliases: [:magic_missiles]
irb(main):004:1>
irb(main):005:1*       unit :fireball, value: "2/3 magic_missile", aliases: [:fire, :fireballs]
irb(main):006:1>     unit :ice, value: "2 magic_missile"
irb(main):007:1>     unit :arcane, value: "10 magic_missile"
irb(main):008:1>     unit :ultima, value: "10 arcane"
irb(main):009:1>   end
=> Magic
irb(main):010:0> 1.kg
=> #<Measured::Weight: 1.0 kg>
irb(main):011:0> 5.5.metres
=> #<Measured::Length: 5.5 m>
irb(main):012:0> BigDecimal("1.2345678").arcane
=> #<Magic: 1.2345678 arcane>
```

Closes https://github.com/Shopify/measured/issues/39