### PR TITLE
Remove unused concept of a "base unit"

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ Extending this library to support other units is simple. To add a new conversion
 
 ```ruby
 Measured::Thing = Measured.build do
-  base :base_unit,           # Define the basic unit for the system
+  unit :base_unit,           # Add a unit to the system
     aliases: [:bu]           # Allow it to be aliased to other names/symbols
 
   unit :another_unit,        # Add a second unit to the system
@@ -177,13 +177,13 @@ By default all names and aliases are case insensitive. If you would like to crea
 
 ```ruby
 Measured::Thing = Measured.build(case_sensitive: true) do
-  base :base_unit, aliases: [:bu]
+  unit :base_unit, aliases: [:bu]
 end
 ```
 
 Other than case sensitivity, both classes are identical to each other. The `case_sensitive` flag, which is false by default, gets taken into account any time you attempt to reference a unit by name or alias.
 
-The base unit takes no value. Values for conversion units can be defined as a string with two tokens `"number unit"` or as an array with two elements. The numbers must be `Rational` or `BigDecimal`, else they will be coerced to `BigDecimal`. Conversion paths don't have to be direct as a conversion table will be built for all possible conversions.
+Values for conversion units can be defined as a string with two tokens `"number unit"` or as an array with two elements. The numbers must be `Rational` or `BigDecimal`, else they will be coerced to `BigDecimal`. Conversion paths don't have to be direct as a conversion table will be built for all possible conversions.
 
 ### Namespaces
 

--- a/lib/measured/conversion.rb
+++ b/lib/measured/conversion.rb
@@ -1,12 +1,10 @@
 class Measured::Conversion
   ARBITRARY_CONVERSION_PRECISION = 20
 
-  attr_reader :base_unit, :units
+  attr_reader :units
 
-  def initialize(base_unit, units)
-    @base_unit = base_unit
+  def initialize(units)
     @units = units.dup
-    @units << @base_unit
   end
 
   def unit_names_with_aliases

--- a/lib/measured/conversion_builder.rb
+++ b/lib/measured/conversion_builder.rb
@@ -1,24 +1,16 @@
 class Measured::ConversionBuilder
   def initialize(case_sensitive: false)
-    @base_unit = nil
     @units = []
     @case_sensitive = case_sensitive
   end
 
-  def base(unit_name, aliases: [])
-    raise Measured::UnitError, "Setting #{unit_name} as base unit, but already defined as #{@base_unit}." if @base_unit
-    @base_unit = build_unit(unit_name, aliases: aliases)
-    nil
-  end
-
-  def unit(unit_name, aliases: [], value:)
+  def unit(unit_name, aliases: [], value: nil)
     @units << build_unit(unit_name, aliases: aliases, value: value)
     nil
   end
 
   def conversion
-    raise Measured::UnitError, "A base unit has not been set." unless @base_unit
-    conversion_class.new(@base_unit, @units)
+    conversion_class.new(@units)
   end
 
   private
@@ -39,8 +31,6 @@ class Measured::ConversionBuilder
 
   def check_for_duplicate_unit_names!(unit)
     names = @units.flat_map(&:names)
-    names += @base_unit.names if @base_unit
-
     if names.any? { |name| unit.names.include?(name) }
       raise Measured::UnitError, "Unit #{unit.name} has already been added."
     end

--- a/lib/measured/units/length.rb
+++ b/lib/measured/units/length.rb
@@ -1,6 +1,5 @@
 Measured::Length = Measured.build do
-  base :m, aliases: [:meter, :metre, :meters, :metres]
-
+  unit :m, aliases: [:meter, :metre, :meters, :metres]
   unit :cm, value: "0.01   m", aliases: [:centimeter, :centimetre, :centimeters, :centimetres]
   unit :mm, value: "0.001  m", aliases: [:millimeter, :millimetre, :millimeters, :millimetres]
   unit :in, value: "0.0254 m", aliases: [:inch, :inches]

--- a/lib/measured/units/weight.rb
+++ b/lib/measured/units/weight.rb
@@ -1,6 +1,5 @@
 Measured::Weight = Measured.build do
-  base :g, aliases: [:gram, :grams]
-
+  unit :g, aliases: [:gram, :grams]
   unit :kg, value: "1000 g", aliases: [:kilogram, :kilograms]
   unit :oz, value: [Rational(1, 16), "lb"], aliases: [:ounce, :ounces]
   unit :lb, value: [Rational(45359237, 1e8), "kg"], aliases: [:lbs, :pound, :pounds]

--- a/test/case_insensitive_conversion_test.rb
+++ b/test/case_insensitive_conversion_test.rb
@@ -2,13 +2,11 @@ require "test_helper"
 
 class Measured::CaseInsensitiveConversionTest < ActiveSupport::TestCase
   setup do
-    @base = Measured::CaseInsensitiveUnit.new(:m)
-    @units = [
+    @conversion = Measured::CaseInsensitiveConversion.new([
+      Measured::CaseInsensitiveUnit.new(:m),
       Measured::CaseInsensitiveUnit.new(:in, aliases: [:inch], value: "0.0254 m"),
       Measured::CaseInsensitiveUnit.new(:ft, aliases: [:feet, :foot], value: "0.3048 m"),
-    ]
-
-    @conversion = Measured::CaseInsensitiveConversion.new(@base, @units)
+    ])
   end
 
   test "#unit_names_with_aliases lists all allowed unit names" do

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -10,7 +10,7 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
     assert_equal "pie", @unit.name
   end
 
-  test "#initialize converts aliases to strings and makes a list of sorted, downcased names which includes the base" do
+  test "#initialize converts aliases to strings and makes a list of sorted, downcased names" do
     assert_equal %w(cake pie sweets), Measured::CaseInsensitiveUnit.new(:pie, aliases: ["Cake", :Sweets]).names
   end
 

--- a/test/conversion_builder_test.rb
+++ b/test/conversion_builder_test.rb
@@ -1,31 +1,9 @@
 require "test_helper"
 
 class Measured::ConversionBuilderTest < ActiveSupport::TestCase
-  test "#base sets the base unit" do
-    conversion = Measured.build { base :m, aliases: [:metre] }.conversion
-    assert_equal ["m", "metre"], conversion.base_unit.names
-  end
-
-  test "#base doesn't allow a second base to be added" do
-    assert_raises Measured::UnitError do
-      Measured.build do
-        base :m, aliases: [:metre]
-        base :in
-      end
-    end
-  end
-
-  test "raises UnitError when no base unit set" do
-    assert_raises Measured::UnitError do
-      Measured.build do
-        unit :m, aliases: [:metre], value: "100 cm"
-      end
-    end
-  end
-
   test "#unit adds a new unit" do
     measurable = Measured.build do
-      base :m
+      unit :m
       unit :in, aliases: [:inch], value: "0.0254 m"
     end
 
@@ -35,7 +13,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
   test "#unit cannot add duplicate unit names" do
     assert_raises Measured::UnitError do
       Measured.build do
-        base :m
+        unit :m
         unit :in, aliases: [:inch], value: "0.0254 m"
         unit :in, aliases: [:thing], value: "123 m"
       end
@@ -43,7 +21,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
 
     assert_raises Measured::UnitError do
       Measured.build(case_sensitive: true) do
-        base :m
+        unit :m
         unit :in, aliases: [:inch], value: "0.0254 m"
         unit :inch, aliases: [:thing], value: "123 m"
       end
@@ -51,7 +29,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
 
     assert_raises Measured::UnitError do
       Measured.build(case_sensitive: false) do
-        base :normal
+        unit :normal
         unit :bold, aliases: [:strong], value: "10 normal"
         unit :bolder, aliases: [:BOLD], value: "100 normal"
       end
@@ -60,7 +38,7 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
 
   test "#case_sensitive true produces a case-sensitive conversion" do
     measurable = Measured.build(case_sensitive: true) do
-      base :normal
+      unit :normal
       unit :bold, value: "10 normal"
       unit :BOLD, value: "100 normal"
     end
@@ -68,9 +46,9 @@ class Measured::ConversionBuilderTest < ActiveSupport::TestCase
     assert_equal 2, measurable.new(200, :normal).convert_to(:BOLD).value
   end
 
-  test "case-insensitive conversion is produced by defaul" do
+  test "case-insensitive conversion is produced by default" do
     measurable = Measured.build(case_sensitive: false) do
-      base :normal
+      unit :normal
       unit :bold, value: "10 normal"
       unit :bolder, value: "100 normal"
     end

--- a/test/conversion_test.rb
+++ b/test/conversion_test.rb
@@ -2,20 +2,18 @@ require "test_helper"
 
 class Measured::ConversionTest < ActiveSupport::TestCase
   setup do
-    @base = Measured::Unit.new(:m)
-    @units = [
+    @conversion = Measured::Conversion.new([
+      Measured::Unit.new(:m),
       Measured::Unit.new(:in, aliases: [:Inch], value: "0.0254 m"),
       Measured::Unit.new(:ft, aliases: [:Feet, :Foot], value: "0.3048 m"),
-    ]
-
-    @conversion = Measured::Conversion.new(@base, @units)
+    ])
   end
 
   test "#unit_names_with_aliases lists all allowed unit names" do
     assert_equal ["Feet", "Foot", "Inch", "ft", "in", "m"], @conversion.unit_names_with_aliases
   end
 
-  test "#unit_names lists all base unit names without aliases" do
+  test "#unit_names lists all unit names without aliases" do
     assert_equal ["ft", "in", "m"], @conversion.unit_names
   end
 

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -89,7 +89,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal conversion.__id__, CaseSensitiveMagic.conversion.__id__
   end
 
-  test ".units returns just the base units" do
+  test ".units returns just the base unit names" do
     assert_equal ["arcane", "fireball", "ice", "magic_missile", "ultima"], Magic.units
   end
 
@@ -106,7 +106,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test ".name looks at the class name" do
     module Example
-      VeryComplexThing = Measured.build { base :foo }
+      VeryComplexThing = Measured.build { unit :foo }
     end
 
     assert_equal "magic", Magic.name

--- a/test/support/fake_system.rb
+++ b/test/support/fake_system.rb
@@ -1,6 +1,5 @@
 Magic = Measured.build do
-  base :magic_missile, aliases: [:magic_missiles]
-
+  unit :magic_missile, aliases: [:magic_missiles]
   unit :fireball, value: "2/3 magic_missile", aliases: [:fire, :fireballs]
   unit :ice, value: "2 magic_missile"
   unit :arcane, value: "10 magic_missile"
@@ -8,8 +7,7 @@ Magic = Measured.build do
 end
 
 CaseSensitiveMagic = Measured.build(case_sensitive: true) do
-  base :magic_missile, aliases: [:magic_missiles]
-
+  unit :magic_missile, aliases: [:magic_missiles]
   unit :fireball, value: "2/3 magic_missile", aliases: [:fire, :fireballs]
   unit :ice, value: "2 magic_missile"
   unit :arcane, value: "10 magic_missile"
@@ -17,7 +15,6 @@ CaseSensitiveMagic = Measured.build(case_sensitive: true) do
 end
 
 OtherFakeSystem = Measured.build do
-  base :other_fake_base
-
+  unit :other_fake_base
   unit :other_fake1, value: "2 other_fake_base"
 end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -10,7 +10,7 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal "Pie", @unit.name
   end
 
-  test "#initialize converts aliases to strings and makes a list of sorted names which includes the base" do
+  test "#initialize converts aliases to strings and makes a list of sorted names" do
     assert_equal %w(Cake pie sweets), Measured::Unit.new(:pie, aliases: ["Cake", :sweets]).names
   end
 

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -5,7 +5,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
     assert_equal ["centimeter", "centimeters", "centimetre", "centimetres", "cm", "feet", "foot", "ft", "in", "inch", "inches", "m", "meter", "meters", "metre", "metres", "millimeter", "millimeters", "millimetre", "millimetres", "mm", "yard", "yards", "yd"], Measured::Length.units_with_aliases
   end
 
-  test ".units should be the list of base units" do
+  test ".units should be the list of base unit names" do
     assert_equal ["cm", "ft", "in", "m", "mm", "yd"], Measured::Length.units
   end
 

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -9,7 +9,7 @@ class Measured::WeightTest < ActiveSupport::TestCase
     assert_equal ["g", "gram", "grams", "kg", "kilogram", "kilograms", "lb", "lbs", "ounce", "ounces", "oz", "pound", "pounds"], Measured::Weight.units_with_aliases
   end
 
-  test ".units should be the list of base units" do
+  test ".units should be the list of base unit names" do
     assert_equal ["g", "kg", "lb", "oz"], Measured::Weight.units
   end
 


### PR DESCRIPTION
Closes https://github.com/Shopify/measured/issues/60

The concept of a "base unit" was completely unused, so to prevent any confusion as to the importance of a base unit we'll remove it. Whenever we reference "base unit" now (in documentation / tests) we're talking about the base name for a unit (i.e., not an alias).