### PR TITLE
Simplify Measurable initializer

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -7,7 +7,7 @@ class Measured::Measurable < Numeric
     raise Measured::UnitError, "Unit '#{unit}' does not exist" unless self.class.conversion.unit_or_alias?(unit)
     raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
-    @value = BigDecimal(value, value.is_a?(Float) : Float::DIG + 1 : 0)
+    @value = BigDecimal(value, value.is_a?(Float) ? Float::DIG + 1 : 0)
     @unit = self.class.conversion.to_unit_name(unit)
   end
 

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -7,8 +7,15 @@ class Measured::Measurable < Numeric
     raise Measured::UnitError, "Unit '#{unit}' does not exist" unless self.class.conversion.unit_or_alias?(unit)
     raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
-    @value = BigDecimal(value, value.is_a?(Float) ? Float::DIG + 1 : 0)
     @unit = self.class.conversion.to_unit_name(unit)
+    @value = case value
+    when Float
+      BigDecimal(value, Float::DIG + 1)
+    when BigDecimal
+      value
+    else
+      BigDecimal(value)
+    end
   end
 
   def convert_to(new_unit)

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -4,26 +4,10 @@ class Measured::Measurable < Numeric
   attr_reader :unit, :value
 
   def initialize(value, unit)
-    raise Measured::UnitError, "Unit cannot be blank" if unit.blank?
-    raise Measured::UnitError, "Unit #{ unit } does not exist" unless self.class.conversion.unit_or_alias?(unit)
+    raise Measured::UnitError, "Unit '#{unit}' does not exist" unless self.class.conversion.unit_or_alias?(unit)
+    raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
-    @value = case value
-    when Float
-      BigDecimal(value, Float::DIG+1)
-    when Integer
-      BigDecimal(value)
-    when NilClass
-      raise Measured::UnitError, "Unit value cannot be nil"
-    when BigDecimal
-      value
-    else
-      if value.blank?
-        raise Measured::UnitError, "Unit value cannot be blank"
-      else
-        BigDecimal(value)
-      end
-    end
-
+    @value = BigDecimal(value, value.is_a?(Float) : Float::DIG + 1 : 0)
     @unit = self.class.conversion.to_unit_name(unit)
   end
 

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -50,14 +50,14 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     exception = assert_raises(Measured::UnitError) do
       Magic.new(nil, :fire)
     end
-    assert_equal "Unit value cannot be nil", exception.message
+    assert_equal "Unit value cannot be blank", exception.message
   end
 
   test "#initialize raises an expected error when initializing with nil unit" do
     exception = assert_raises(Measured::UnitError) do
       Magic.new(1, nil)
     end
-    assert_equal "Unit cannot be blank", exception.message
+    assert_equal "Unit '' does not exist", exception.message
   end
 
   test "#initialize raises an expected error when initializing with empty string value" do
@@ -71,7 +71,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     exception = assert_raises(Measured::UnitError) do
       Magic.new(1, "")
     end
-    assert_equal "Unit cannot be blank", exception.message
+    assert_equal "Unit '' does not exist", exception.message
   end
 
   test "#unit allows you to read the unit string" do


### PR DESCRIPTION
Closes https://github.com/Shopify/measured/issues/35

- Removes the blank check on the unit and defers validity checks to `unit_or_alias?`
- Removes the big `case` block, deferring parsing to `BigDecimal`

## Benchmarking

Not a huge boost, about 1.1x - 1.15.x. There's still a hit for `BigDecimal`'s type checks, and we need to have a precision for floats.

__Before__
```
Warming up --------------------------------------
              before    31.165k i/100ms
Calculating -------------------------------------
              before    347.351k (± 4.7%) i/s -      1.745M in   5.037722s
```

__After__
```
Warming up --------------------------------------
               after    33.800k i/100ms
Calculating -------------------------------------
               after    385.849k (± 2.6%) i/s -      1.960M in   5.084211s
```