### PR TITLE
Use Rational where appropriate

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Encapsulates measurements with their units. Provides easy conversion between units.
 
-Light weight and easily extensible to include other units and conversions. Conversions done with `BigDecimal` for precision.
+Lightweight and easily extensible to include other units and conversions. Conversions done with `Rational` for precision.
 
 The adapter to integrate `measured` with Ruby on Rails is in a separate [`measured-rails`](https://github.com/Shopify/measured-rails) gem.
 
@@ -56,13 +56,13 @@ rescue Measured::UnitError
 end
 ```
 
-Perform addition / subtraction against other units, all represented internally as `BigDecimal`:
+Perform addition / subtraction against other units, all represented internally as `Rational` or `BigDecimal`:
 
 ```ruby
 Measured::Weight.new(1, :g) + Measured::Weight.new(2, :g)
 > #<Measured::Weight 3 g>
-Measured::Weight.new(2, :g) - Measured::Weight.new(1, :g)
-> #<Measured::Weight 1 g>
+Measured::Weight.new("2.1", :g) - Measured::Weight.new(1, :g)
+> #<Measured::Weight 1.1 g>
 ```
 
 Multiplication and division by units is not supported, but the actual value can be scaled by a scalar:
@@ -166,10 +166,6 @@ Measured::Thing = Measured.build do
   unit :another_unit,        # Add a second unit to the system
     aliases: [:au],          # All units allow aliases, as long as they are unique
     value: ["1.5 bu"]        # The conversion rate to another unit
-
-  unit :different_unit
-    aliases: [:du],
-    value: [Rational(2,3), "au"]  # Conversion rate can be Rational, otherwise it is coerced to BigDecimal
 end
 ```
 
@@ -183,7 +179,7 @@ end
 
 Other than case sensitivity, both classes are identical to each other. The `case_sensitive` flag, which is false by default, gets taken into account any time you attempt to reference a unit by name or alias.
 
-Values for conversion units can be defined as a string with two tokens `"number unit"` or as an array with two elements. The numbers must be `Rational` or `BigDecimal`, else they will be coerced to `BigDecimal`. Conversion paths don't have to be direct as a conversion table will be built for all possible conversions.
+Values for conversion units can be defined as a string with two tokens `"number unit"` or as an array with two elements. All values will be parsed as / coerced to `Rational`. Conversion paths don't have to be direct as a conversion table will be built for all possible conversions.
 
 ### Namespaces
 
@@ -209,7 +205,7 @@ Existing alternatives which were considered:
 
 ### Gem: [quantified](https://github.com/Shopify/quantified)
 * **Pros**
-  * Light weight.
+  * Lightweight.
   * Included with ActiveShipping/ActiveUtils.
 * **Cons**
   * All math done with floats making it highly lossy.

--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -41,7 +41,7 @@ module Measured::ConversionTable
   end
 
   def find_tree_traversal_conversion(units, to:, from:)
-    traverse(units, from: from, to: to, unit_names: units.map{|u| u.name }, amount: Rational(1))
+    traverse(units, from: from, to: to, unit_names: units.map(&:name), amount: 1)
   end
 
   def traverse(units, from:, to:, unit_names:, amount:)
@@ -49,7 +49,7 @@ module Measured::ConversionTable
 
     unit_names.each do |name|
       if conversion = find_direct_conversion(units, from: from, to: name)
-        new_amount = amount * conversion.to_r
+        new_amount = amount * conversion
         if name == to
           return new_amount
         else

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -11,8 +11,10 @@ class Measured::Measurable < Numeric
     @value = case value
     when Float
       BigDecimal(value, Float::DIG + 1)
-    when BigDecimal
+    when BigDecimal, Rational
       value
+    when Integer
+      Rational(value)
     else
       BigDecimal(value)
     end
@@ -28,11 +30,11 @@ class Measured::Measurable < Numeric
   end
 
   def to_s
-    [value.to_f.to_s.gsub(/\.0\Z/, ""), unit].join(" ")
+    @to_s ||= "#{value_string} #{unit}"
   end
 
   def inspect
-    "#<#{ self.class }: #{ value } #{ unit }>"
+    @inspect ||= "#<#{self.class}: #{value_string} #{unit}>"
   end
 
   def <=>(other)
@@ -65,5 +67,21 @@ class Measured::Measurable < Numeric
       to_s.split("::").last.underscore.humanize.downcase
     end
 
+  end
+
+  private
+
+  def value_string
+    @value_string ||= begin
+      str = case value
+      when Rational
+        value.denominator == 1 ? value.numerator.to_s : value.to_f.to_s
+      when BigDecimal
+        value.to_s("F")
+      else
+        value.to_f.to_s
+      end
+      str.gsub(/\.0*\Z/, "")
+    end
   end
 end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -45,10 +45,9 @@ class Measured::Unit
 
   def parse_value(tokens)
     tokens = tokens.split(" ") if tokens.is_a?(String)
-    raise Measured::UnitError, "Cannot parse 'number unit' or [number, unit] formatted tokens from #{ tokens }." unless tokens.size == 2
 
-    tokens[0] = BigDecimal(tokens[0]) unless tokens[0].is_a?(BigDecimal) || tokens[0].is_a?(Rational)
+    raise Measured::UnitError, "Cannot parse 'number unit' or [number, unit] formatted tokens from #{tokens}." unless tokens.size == 2
 
-    tokens
+    [tokens[0].to_r, tokens[1]]
   end
 end

--- a/lib/measured/units/length.rb
+++ b/lib/measured/units/length.rb
@@ -1,8 +1,8 @@
 Measured::Length = Measured.build do
   unit :m, aliases: [:meter, :metre, :meters, :metres]
-  unit :cm, value: "0.01   m", aliases: [:centimeter, :centimetre, :centimeters, :centimetres]
-  unit :mm, value: "0.001  m", aliases: [:millimeter, :millimetre, :millimeters, :millimetres]
+  unit :cm, value: "1/100 m", aliases: [:centimeter, :centimetre, :centimeters, :centimetres]
+  unit :mm, value: "1/1000 m", aliases: [:millimeter, :millimetre, :millimeters, :millimetres]
   unit :in, value: "0.0254 m", aliases: [:inch, :inches]
-  unit :ft, value: "0.3048 m", aliases: [:foot, :feet]
-  unit :yd, value: "0.9144 m", aliases: [:yard, :yards]
+  unit :ft, value: "12 in", aliases: [:foot, :feet]
+  unit :yd, value: "3 ft", aliases: [:yard, :yards]
 end

--- a/lib/measured/units/weight.rb
+++ b/lib/measured/units/weight.rb
@@ -1,6 +1,6 @@
 Measured::Weight = Measured.build do
   unit :g, aliases: [:gram, :grams]
   unit :kg, value: "1000 g", aliases: [:kilogram, :kilograms]
-  unit :oz, value: [Rational(1, 16), "lb"], aliases: [:ounce, :ounces]
-  unit :lb, value: [Rational(45359237, 1e8), "kg"], aliases: [:lbs, :pound, :pounds]
+  unit :lb, value: "0.45359237 kg", aliases: [:lbs, :pound, :pounds]
+  unit :oz, value: "1/16 lb", aliases: [:ounce, :ounces]
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -141,7 +141,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test "#inspect shows the number and the unit" do
-    assert_equal "#<Magic: 10.0 fireball>", Magic.new(10, :fire).inspect
+    assert_equal "#<Magic: 10 fireball>", Magic.new(10, :fire).inspect
     assert_equal "#<Magic: 1.234 magic_missile>", Magic.new(1.234, :magic_missile).inspect
   end
 
@@ -152,9 +152,9 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test "#<=> compares regardless of the unit" do
-    assert_equal -1, @magic <=> Magic.new(10, :fire)
+    assert_equal -1, @magic <=> Magic.new(20, :fire)
     assert_equal 1, @magic <=> Magic.new(9, :magic_missile)
-    assert_equal 0, @magic <=> Magic.new(10, :magic_missile)
+    assert_equal 0, @magic <=> Magic.new(Rational(30, 2), :fire)
     assert_equal -1, @magic <=> Magic.new(11, :magic_missile)
   end
 


### PR DESCRIPTION
See https://github.com/Shopify/measured/issues/63 for more context. tl;dr `Rational` is faster for arithmetic and can represent values that `BigDecimal` cannot, but slower for parsing decimal numbers. Since the construction of units and the conversion table is a one-off operation, `Rational` is the best for representing things, especially since conversions are arithmetic operations.

Mostly takes care of https://github.com/Shopify/measured/issues/63, but I have some other changes that I want to make that'll fully close it.