### PR TITLE
Clarify the bang-ness of to_unit_name

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -4,10 +4,9 @@ class Measured::Measurable < Numeric
   attr_reader :unit, :value
 
   def initialize(value, unit)
-    raise Measured::UnitError, "Unit '#{unit}' does not exist" unless self.class.valid_unit?(unit)
     raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
-    @unit = self.class.unit_system.to_unit_name(unit)
+    @unit = self.class.unit_system.to_unit_name!(unit)
     @value = case value
     when Float
       BigDecimal(value, Float::DIG + 1)

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -25,7 +25,9 @@ class Measured::UnitSystem
   end
 
   def to_unit_name(name)
-    to_unit_name!(name) rescue nil
+    to_unit_name!(name)
+  rescue Measured::UnitError
+    nil
   end
 
   def to_unit_name!(name)

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -25,6 +25,10 @@ class Measured::UnitSystem
   end
 
   def to_unit_name(name)
+    to_unit_name!(name) rescue nil
+  end
+
+  def to_unit_name!(name)
     unit_for!(name).name
   end
 
@@ -57,7 +61,7 @@ class Measured::UnitSystem
 
   def unit_for!(name)
     unit = unit_for(name)
-    raise Measured::UnitError, "Cannot find unit for #{name}" unless unit
+    raise Measured::UnitError, "Unit '#{name}' does not exist" unless unit
     unit
   end
 end

--- a/test/case_insensitive_unit_system_test.rb
+++ b/test/case_insensitive_unit_system_test.rb
@@ -72,7 +72,7 @@ class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
   end
 
   test "#to_unit_name! raises if not found" do
-    assert_raises Measured::UnitError do
+    assert_raises_with_message(Measured::UnitError, "Unit 'thunder' does not exist") do
       Magic.unit_system.to_unit_name!("thunder")
     end
   end

--- a/test/case_insensitive_unit_system_test.rb
+++ b/test/case_insensitive_unit_system_test.rb
@@ -55,9 +55,25 @@ class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
     assert_equal "fireball", Magic.unit_system.to_unit_name("fireball")
   end
 
-  test "#to_unit_name raises if not found" do
+  test "#to_unit_name returns nil if not found" do
+    assert_nil Magic.unit_system.to_unit_name("thunder")
+  end
+
+  test "#to_unit_name! converts a unit name to its base unit" do
+    assert_equal "fireball", Magic.unit_system.to_unit_name!("fire")
+  end
+
+  test "#to_unit_name! does not care about string or symbol" do
+    assert_equal "fireball", Magic.unit_system.to_unit_name!(:fire)
+  end
+
+  test "#to_unit_name! passes through if already base unit name" do
+    assert_equal "fireball", Magic.unit_system.to_unit_name!("fireball")
+  end
+
+  test "#to_unit_name! raises if not found" do
     assert_raises Measured::UnitError do
-      Magic.unit_system.to_unit_name("thunder")
+      Magic.unit_system.to_unit_name!("thunder")
     end
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -32,4 +32,9 @@ class ActiveSupport::TestCase
 
     assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
+
+  def assert_raises_with_message(exception, expected_message)
+    error = assert_raise(exception) { yield }
+    assert_equal expected_message, error.message, "Exception #{exception} raised but messages are not equal"
+  end
 end

--- a/test/unit_system_test.rb
+++ b/test/unit_system_test.rb
@@ -56,9 +56,25 @@ class Measured::UnitSystemTest < ActiveSupport::TestCase
     assert_equal "fireball", CaseSensitiveMagic.unit_system.to_unit_name("fireball")
   end
 
-  test "#to_unit_name raises if not found" do
+  test "#to_unit_name returns nil if not found" do
+    assert_nil CaseSensitiveMagic.unit_system.to_unit_name("thunder")
+  end
+
+  test "#to_unit_name! converts a unit name to its base unit" do
+    assert_equal "fireball", CaseSensitiveMagic.unit_system.to_unit_name!("fire")
+  end
+
+  test "#to_unit_name! does not care about string or symbol" do
+    assert_equal "fireball", CaseSensitiveMagic.unit_system.to_unit_name!(:fire)
+  end
+
+  test "#to_unit_name! passes through if already base unit name" do
+    assert_equal "fireball", CaseSensitiveMagic.unit_system.to_unit_name!("fireball")
+  end
+
+  test "#to_unit_name! raises if not found" do
     assert_raises Measured::UnitError do
-      CaseSensitiveMagic.unit_system.to_unit_name("thunder")
+      CaseSensitiveMagic.unit_system.to_unit_name!("thunder")
     end
   end
 

--- a/test/unit_system_test.rb
+++ b/test/unit_system_test.rb
@@ -73,7 +73,7 @@ class Measured::UnitSystemTest < ActiveSupport::TestCase
   end
 
   test "#to_unit_name! raises if not found" do
-    assert_raises Measured::UnitError do
+    assert_raises_with_message(Measured::UnitError, "Unit 'thunder' does not exist") do
       CaseSensitiveMagic.unit_system.to_unit_name!("thunder")
     end
   end


### PR DESCRIPTION
Previously we had `to_unit_name`, but this method could raise, so it should have a bang suffix.

I've resolved this by having both `to_unit_name` and `to_unit_name!`, and using the `raise`-ing nature of `to_unit_name!` to simplify `Measurable#initialize`.