### PR TITLE
Delegate names exactly to UnitSystem instead of aliasing

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -45,27 +45,19 @@ class Measured::Measurable < Numeric
   end
 
   class << self
+    extend Forwardable
 
     def unit_system
       raise "`Measurable` does not have a `unit_system` object. You cannot directly subclass `Measurable`. Instead, build a new unit system by calling `Measured.build`."
     end
 
-    def units
-      unit_system.unit_names
-    end
-
-    def valid_unit?(unit)
-      unit_system.unit_or_alias?(unit)
-    end
-
-    def units_with_aliases
-      unit_system.unit_names_with_aliases
-    end
+    delegate unit_names: :unit_system
+    delegate unit_names_with_aliases: :unit_system
+    delegate unit_or_alias?: :unit_system
 
     def name
       to_s.split("::").last.underscore.humanize.downcase
     end
-
   end
 
   private

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -89,19 +89,22 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal conversion.__id__, CaseSensitiveMagic.unit_system.__id__
   end
 
-  test ".units returns just the base unit names" do
-    assert_equal ["arcane", "fireball", "ice", "magic_missile", "ultima"], Magic.units
+  test ".unit_names returns just the base unit names" do
+    assert_equal %w(arcane fireball ice magic_missile ultima), Magic.unit_names
   end
 
-  test ".units_with_aliases returns all units" do
-    assert_equal ["arcane", "fire", "fireball", "fireballs", "ice", "magic_missile", "magic_missiles", "ultima"], Magic.units_with_aliases
+  test ".unit_names_with_aliases returns all units" do
+    assert_equal(
+      %w(arcane fire fireball fireballs ice magic_missile magic_missiles ultima),
+      Magic.unit_names_with_aliases
+    )
   end
 
-  test ".valid_unit? looks at the list of units and aliases" do
-    assert Magic.valid_unit?("fire")
-    assert Magic.valid_unit?("fireball")
-    assert Magic.valid_unit?(:ice)
-    refute Magic.valid_unit?("junk")
+  test ".unit_or_alias? looks at the list of units and aliases" do
+    assert Magic.unit_or_alias?("fire")
+    assert Magic.unit_or_alias?("fireball")
+    assert Magic.unit_or_alias?(:ice)
+    refute Magic.unit_or_alias?("junk")
   end
 
   test ".name looks at the class name" do

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -7,7 +7,7 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
       unit :in, aliases: [:inch], value: "0.0254 m"
     end
 
-    assert_equal 2, measurable.units.count
+    assert_equal 2, measurable.unit_names.count
   end
 
   test "#unit cannot add duplicate unit names" do

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -1,12 +1,19 @@
 require "test_helper"
 
 class Measured::LengthTest < ActiveSupport::TestCase
-  test ".units_with_aliases should be the expected list of valid units" do
-    assert_equal ["centimeter", "centimeters", "centimetre", "centimetres", "cm", "feet", "foot", "ft", "in", "inch", "inches", "m", "meter", "meters", "metre", "metres", "millimeter", "millimeters", "millimetre", "millimetres", "mm", "yard", "yards", "yd"], Measured::Length.units_with_aliases
+  test ".unit_names_with_aliases should be the expected list of valid units" do
+    assert_equal(
+      %w(
+        centimeter centimeters centimetre centimetres cm feet foot ft
+        in inch inches m meter meters metre metres millimeter
+        millimeters millimetre millimetres mm yard yards yd
+      ),
+      Measured::Length.unit_names_with_aliases
+    )
   end
 
-  test ".units should be the list of base unit names" do
-    assert_equal ["cm", "ft", "in", "m", "mm", "yd"], Measured::Length.units
+  test ".unit_names should be the list of base unit names" do
+    assert_equal %w(cm ft in m mm yd), Measured::Length.unit_names
   end
 
   test ".name" do

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -5,12 +5,15 @@ class Measured::WeightTest < ActiveSupport::TestCase
     @weight = Measured::Weight.new(1, "g")
   end
 
-  test ".units_with_aliases should be the expected list of valid units" do
-    assert_equal ["g", "gram", "grams", "kg", "kilogram", "kilograms", "lb", "lbs", "ounce", "ounces", "oz", "pound", "pounds"], Measured::Weight.units_with_aliases
+  test ".unit_names_with_aliases should be the expected list of valid units" do
+    assert_equal(
+      %w(g gram grams kg kilogram kilograms lb lbs ounce ounces oz pound pounds),
+      Measured::Weight.unit_names_with_aliases
+    )
   end
 
-  test ".units should be the list of base unit names" do
-    assert_equal ["g", "kg", "lb", "oz"], Measured::Weight.units
+  test ".unit_names should be the list of base unit names" do
+    assert_equal %w(g kg lb oz), Measured::Weight.unit_names
   end
 
 


### PR DESCRIPTION
Note: will switch to merging into master after https://github.com/Shopify/measured/pull/66 merged

It was confusing to have two sets of names for the exact same operations. To ease any future refactoring efforts and simplify the system, just delegate the names exactly as they are in `UnitSystem`.

Moved to using `%w` for lists of unit names in tests that I had to update.