### PR TITLE
Make unit comparison behave as expected

### DIFF
--- a/lib/measured/case_insensitive_unit.rb
+++ b/lib/measured/case_insensitive_unit.rb
@@ -2,12 +2,4 @@ class Measured::CaseInsensitiveUnit < Measured::Unit
   def initialize(name, aliases: [], value: nil)
     super(name.to_s.downcase, aliases: aliases.map(&:to_s).map!(&:downcase), value: value)
   end
-
-  def name_eql?(name_to_compare)
-    super(name_to_compare.to_s.downcase)
-  end
-
-  def names_include?(name_to_compare)
-    super(name_to_compare.to_s.downcase)
-  end
 end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -23,9 +23,9 @@ class Measured::Unit
 
   def <=>(other)
     if self.class == other.class
-      name_cmp = @names <=> other.names
-      if name_cmp != 0
-        name_cmp
+      names_comparison = @names <=> other.names
+      if names_comparison != 0
+        names_comparison
       else
         @conversion_amount <=> other.conversion_amount
       end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -23,10 +23,11 @@ class Measured::Unit
 
   def <=>(other)
     if self.class == other.class
-      if other.names != @names
-        other.names <=> @names
+      name_cmp = @names <=> other.names
+      if name_cmp != 0
+        name_cmp
       else
-        other.conversion_amount <=> @conversion_amount
+        @conversion_amount <=> other.conversion_amount
       end
     else
       @name <=> other

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -62,10 +62,15 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
     assert_equal 0, @unit <=> Measured::CaseInsensitiveUnit.new("Pie", value: [10, :cake])
   end
 
-  test "#<=> is 1 for " do
-    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pies, value: "10 cake")
-    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new("pie", aliases: ["pies"], value: "10 cake")
-    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pie, value: [11, :cake])
+  test "#<=> is 1 for units with names that come after Pie lexicographically" do
+    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pancake, value: "10 cake")
+    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new("pie", aliases: ["pancakes"], value: "10 cake")
+  end
+
+  test "#<=> compares #conversion_amount when unit names the same" do
+    assert_equal -1, @unit <=> Measured::CaseInsensitiveUnit.new(:pie, value: [11, :pancake])
+    assert_equal 0, @unit <=> Measured::CaseInsensitiveUnit.new(:pie, value: [10, :foo])
+    assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pie, value: [9, :pancake])
   end
 
   test "#inverse_conversion_amount returns 1/amount for BigDecimal" do

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -62,10 +62,15 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal 0, @unit <=> Measured::Unit.new("Pie", value: [10, :cake])
   end
 
-  test "#<=> is 1 for units with names that come after Pie lexicographically" do
-    assert_equal 1, @unit <=> Measured::Unit.new(:Pigs, value: "10 bacon")
-    assert_equal 1, @unit <=> Measured::Unit.new("Pig", aliases: %w(Pigs), value: "10 bacon")
-    assert_equal 1, @unit <=> Measured::Unit.new(:Pig, value: [11, :bacon])
+  test "#<=> is -1 for units with names that come after Pie lexicographically" do
+    assert_equal -1, @unit <=> Measured::Unit.new(:Pigs, value: "10 bacon")
+    assert_equal -1, @unit <=> Measured::Unit.new("Pig", aliases: %w(Pigs), value: "10 bacon")
+  end
+  
+  test "#<=> compares #conversion_amount when unit names the same" do
+    assert_equal -1, @unit <=> Measured::Unit.new(:Pie, value: [11, :pancake])
+    assert_equal 0, @unit <=> Measured::Unit.new(:Pie, value: [10, :foo])
+    assert_equal 1, @unit <=> Measured::Unit.new(:Pie, value: [9, :pancake])
   end
 
   test "#inverse_conversion_amount returns 1/amount for BigDecimal" do


### PR DESCRIPTION
When comparing `foo <=> bar`, any attribute of `foo` used for comparison should generally be on the left of `<=>` for a meaningful comparison. We actually have this for one branch of `<=>` (when comparing `@name` against some non-instance of `Unit`), and should have it for the rest.

I've also followed up with adding some tests to emphasize the behaviour of the "names equal" branch, where the conversion value is used for comparison. I don't think this is the most meaningful thing for comparison, but I'll be following up with some changes that will take care of this and wanted to keep this PR leaner.