### PR TITLE
Have Measurable store unit instances instead of names

### DIFF
--- a/lib/measured/case_insensitive_unit_system.rb
+++ b/lib/measured/case_insensitive_unit_system.rb
@@ -3,8 +3,6 @@ class Measured::CaseInsensitiveUnitSystem < Measured::UnitSystem
     super(name.to_s.downcase)
   end
 
-  protected
-
   def unit_for(name)
     unit_name_to_unit[name.to_s.downcase]
   end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -6,7 +6,7 @@ class Measured::Measurable < Numeric
   def initialize(value, unit)
     raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
-    @unit = self.class.unit_system.to_unit_name!(unit)
+    @unit = unit.is_a?(Measured::Unit) ? unit : self.class.unit_system.unit_for!(unit)
     @value = case value
     when Float
       BigDecimal(value, Float::DIG + 1)
@@ -20,10 +20,9 @@ class Measured::Measurable < Numeric
   end
 
   def convert_to(new_unit)
-    new_unit_name = self.class.unit_system.to_unit_name(new_unit)
-    return self if new_unit_name == @unit
+    return self if new_unit == unit
 
-    value = self.class.unit_system.convert(@value, from: @unit, to: new_unit_name)
+    value = self.class.unit_system.convert(self.value, from: unit, to: new_unit)
 
     self.class.new(value, new_unit)
   end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -6,7 +6,7 @@ class Measured::Measurable < Numeric
   def initialize(value, unit)
     raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
-    @unit = unit.is_a?(Measured::Unit) ? unit : self.class.unit_system.unit_for!(unit)
+    @unit = unit_from_unit_or_name!(unit)
     @value = case value
     when Float
       BigDecimal(value, Float::DIG + 1)
@@ -20,6 +20,7 @@ class Measured::Measurable < Numeric
   end
 
   def convert_to(new_unit)
+    new_unit = unit_from_unit_or_name!(new_unit)
     return self if new_unit == unit
 
     value = self.class.unit_system.convert(self.value, from: unit, to: new_unit)
@@ -60,6 +61,10 @@ class Measured::Measurable < Numeric
   end
 
   private
+
+  def unit_from_unit_or_name!(value)
+    value.is_a?(Measured::Unit) ? value : self.class.unit_system.unit_for!(value)
+  end
 
   def value_string
     @value_string ||= begin

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -22,20 +22,18 @@ class Measured::UnitSystem
     unit ? unit.name == name.to_s : false
   end
 
-  def to_unit_name(name)
-    to_unit_name!(name)
-  rescue Measured::UnitError
-    nil
+  def unit_for(name)
+    unit_name_to_unit[name.to_s]
   end
 
-  def to_unit_name!(name)
-    unit_for!(name).name
+  def unit_for!(name)
+    unit = unit_for(name)
+    raise Measured::UnitError, "Unit '#{name}' does not exist" unless unit
+    unit
   end
 
   def convert(value, from:, to:)
-    from_unit = unit_for!(from)
-    to_unit = unit_for!(to)
-    conversion = conversion_table[from][to]
+    conversion = conversion_table.fetch(from.name, {})[to.name]
 
     raise Measured::UnitError, "Cannot find conversion entry from #{from} to #{to}" unless conversion
 
@@ -53,15 +51,5 @@ class Measured::UnitSystem
       unit.names.each { |name| hash[name.to_s] = unit }
       hash
     end
-  end
-
-  def unit_for(name)
-    unit_name_to_unit[name.to_s]
-  end
-
-  def unit_for!(name)
-    unit = unit_for(name)
-    raise Measured::UnitError, "Unit '#{name}' does not exist" unless unit
-    unit
   end
 end

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -79,9 +79,10 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
   test "arithmetic operations favours unit of left" do
     left = Magic.new(1, :arcane)
     right = Magic.new(1, :magic_missile)
+    arcane = Magic.unit_system.unit_for!(:arcane)
 
-    assert_equal "arcane", (left + right).unit
-    assert_equal "arcane", (left - right).unit
+    assert_equal arcane, (left + right).unit
+    assert_equal arcane, (left - right).unit
   end
 
   test "#coerce should return other as-is when same class" do

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -4,6 +4,9 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   setup do
     @magic = Magic.new(10, :magic_missile)
+    @arcane = Magic.unit_system.unit_for!(:arcane)
+    @fireball = Magic.unit_system.unit_for!(:fireball)
+    @magic_missile = Magic.unit_system.unit_for!(:magic_missile)
   end
 
   test "#initialize requires two params, the amount and the unit" do
@@ -18,7 +21,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test "#initialize converts unit to string from symbol" do
     magic = Magic.new(1, :arcane)
-    assert_equal "arcane", magic.unit
+    assert_equal @arcane, magic.unit
   end
 
   test "#initialize raises if it is an unknown unit" do
@@ -42,8 +45,8 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal BigDecimal("9.1234572342342"), Magic.new(9.1234572342342, :fire).value
   end
 
-  test "#initialize converts to the base unit name" do
-    assert_equal "fireball", Magic.new(1, :fire).unit
+  test "#initialize converts to the base unit" do
+    assert_equal @fireball, Magic.new(1, :fire).unit
   end
 
   test "#initialize raises an expected error when initializing with nil value" do
@@ -75,7 +78,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test "#unit allows you to read the unit string" do
-    assert_equal "magic_missile", @magic.unit
+    assert_equal @magic_missile, @magic.unit
   end
 
   test "#value allows you to read the numeric value" do
@@ -118,19 +121,19 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test "#convert_to raises on an invalid unit" do
     assert_raises Measured::UnitError do
-      @magic.convert_to(:punch)
+      @magic.convert_to(Measured::Unit.new(:punch))
     end
   end
 
   test "#convert_to returns a new object of the same type in the new unit" do
-    converted = @magic.convert_to(:arcane)
+    converted = @magic.convert_to(@arcane)
 
     assert_equal converted, @magic
     refute_equal converted.object_id, @magic.object_id
     assert_equal BigDecimal(10), @magic.value
-    assert_equal "magic_missile", @magic.unit
+    assert_equal @magic_missile, @magic.unit
     assert_equal BigDecimal(1), converted.value
-    assert_equal "arcane", converted.unit
+    assert_equal @arcane, converted.unit
   end
 
   test "#convert_to from and to the same unit returns the same object" do
@@ -139,12 +142,12 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test "#to_s outputs the number and the unit" do
-    assert_equal "10 fireball", Magic.new(10, :fire).to_s
+    assert_equal "10 fireball (2/3 magic_missile)", Magic.new(10, :fire).to_s
     assert_equal "1.234 magic_missile", Magic.new("1.234", :magic_missile).to_s
   end
 
   test "#inspect shows the number and the unit" do
-    assert_equal "#<Magic: 10 fireball>", Magic.new(10, :fire).inspect
+    assert_equal "#<Magic: 10 fireball (2/3 magic_missile)>", Magic.new(10, :fire).inspect
     assert_equal "#<Magic: 1.234 magic_missile>", Magic.new(1.234, :magic_missile).inspect
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,6 +23,7 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
+    to_unit = klass.unit_system.unit_for!(to_unit)
     assert_close_bigdecimal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 
@@ -30,6 +31,7 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
+    to_unit = klass.unit_system.unit_for!(to_unit)
     assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -43,7 +43,7 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
       unit :BOLD, value: "100 normal"
     end
 
-    assert_equal 2, measurable.new(200, :normal).convert_to(:BOLD).value
+    assert_equal 'BOLD', measurable.unit_system.unit_for!(:BOLD).name
   end
 
   test "case-insensitive conversion is produced by default" do
@@ -53,6 +53,6 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
       unit :bolder, value: "100 normal"
     end
 
-    assert_equal 20, measurable.new(200, :normal).convert_to(:bOlD).value
+    assert_equal 'bold', measurable.unit_system.unit_for!(:bOlD).name
   end
 end


### PR DESCRIPTION
Right now we're storing unit names instead of `Unit` instances in `Measurable`s, and doing a lot of unnecessary lookups for the `Unit` instances. I think it makes much more sense to store the `Unit` instance itself.

This PR is one piece in the line of changes I need to make to move towards having `Measured.build` return the unit system itself instead of a `Measurable` subclass. Additional comments in line.

Will change to merge into master once https://github.com/Shopify/measured/pull/69 merged.

## Benchmarks
### Same unit conversion
About 8-10% faster.

```ruby
Benchmark.ips do |x|
  x.report { Measured::Weight.new(10, :kg) + Measured::Weight.new(2, :kg) }
end
```

__Before__
```
Warming up --------------------------------------
                        19.306k i/100ms
Calculating -------------------------------------
                        209.369k (± 3.5%) i/s -      1.062M in   5.077847s
```

__After__
```
Warming up --------------------------------------
                        22.056k i/100ms
Calculating -------------------------------------
                        235.309k (± 4.5%) i/s -      1.191M in   5.072082s
```

### Different unit conversion
About 18% faster.

```ruby
Benchmark.ips do |x|
  x.report { Measured::Weight.new(10, :kg) + Measured::Weight.new(2, :g) }
end
```

__Before__
```
Warming up --------------------------------------
                        13.341k i/100ms
Calculating -------------------------------------
                        147.189k (± 4.2%) i/s -    747.096k in   5.085418s
```

__After__
```
Warming up --------------------------------------
                        16.459k i/100ms
Calculating -------------------------------------
                        176.052k (± 3.8%) i/s -    888.786k in   5.056109s
```