### PR TITLE
Have Measured.build return a UnitSystem subclass

### DIFF
--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -8,11 +8,11 @@ module Measured::Arithmetic
   end
 
   def -@
-    self.class.new(-self.value, self.unit)
+    self.class.new(-self.value, self.unit, self.unit_system)
   end
 
   def scale(other)
-    self.class.new(self.value * other, self.unit)
+    self.class.new(self.value * other, self.unit, self.unit_system)
   end
 
   def coerce(other)
@@ -31,6 +31,6 @@ module Measured::Arithmetic
 
   def arithmetic_operation(other, operator)
     other, _ = coerce(other)
-    self.class.new(self.value.public_send(operator, other.convert_to(self.unit).value), self.unit)
+    self.class.new(self.value.public_send(operator, other.convert_to(self.unit).value), self.unit, self.unit_system)
   end
 end

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -17,7 +17,11 @@ module Measured::Arithmetic
 
   def coerce(other)
     if other.is_a?(self.class)
-      [other, self]
+      if self.unit_system == other.unit_system
+        [other, self]
+      else
+        raise TypeError, "Cannot coerce #{other.unit_system} values to #{self.unit_system}"
+      end
     else
       raise TypeError, "Cannot coerce #{other.class} to #{self.class}"
     end

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -8,19 +8,19 @@ module Measured::Arithmetic
   end
 
   def -@
-    self.class.new(-self.value, self.unit, self.unit_system)
+    self.class.new(-self.value, self.unit)
   end
 
   def scale(other)
-    self.class.new(self.value * other, self.unit, self.unit_system)
+    self.class.new(self.value * other, self.unit)
   end
 
   def coerce(other)
     if other.is_a?(self.class)
-      if self.unit_system == other.unit_system
+      if self.unit.unit_system == other.unit.unit_system
         [other, self]
       else
-        raise TypeError, "Cannot coerce #{other.unit_system} values to #{self.unit_system}"
+        raise TypeError, "Cannot coerce '#{other.unit.unit_system.name}' values to '#{self.unit.unit_system.name}'"
       end
     else
       raise TypeError, "Cannot coerce #{other.class} to #{self.class}"
@@ -35,6 +35,6 @@ module Measured::Arithmetic
 
   def arithmetic_operation(other, operator)
     other, _ = coerce(other)
-    self.class.new(self.value.public_send(operator, other.convert_to(self.unit).value), self.unit, self.unit_system)
+    self.class.new(self.value.public_send(operator, other.convert_to(self.unit).value), self.unit)
   end
 end

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -15,7 +15,8 @@ module Measured
     def method_missing(method, *args)
       class_name = "Measured::#{ method }"
 
-      if Measurable.subclasses.map(&:to_s).include?(class_name)
+      subclasses = (UnitSystem.subclasses + CaseInsensitiveUnitSystem.subclasses).map(&:to_s)
+      if subclasses.include?(class_name)
         klass = class_name.constantize
 
         Measured.define_singleton_method(method) do |value, unit|

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -9,14 +9,7 @@ module Measured
     def build(**kwargs, &block)
       builder = UnitSystemBuilder.new(**kwargs)
       builder.instance_eval(&block)
-
-      Class.new(Measurable) do
-        class << self
-          attr_reader :unit_system
-        end
-
-        @unit_system = builder.build
-      end
+      builder.build
     end
 
     def method_missing(method, *args)

--- a/lib/measured/case_insensitive_unit_system.rb
+++ b/lib/measured/case_insensitive_unit_system.rb
@@ -1,9 +1,11 @@
 class Measured::CaseInsensitiveUnitSystem < Measured::UnitSystem
-  def unit?(name)
-    super(name.to_s.downcase)
-  end
+  class << self
+    def unit?(name)
+      super(name.to_s.downcase)
+    end
 
-  def unit_for(name)
-    unit_name_to_unit[name.to_s.downcase]
+    def unit_for(name)
+      unit_name_to_unit[name.to_s.downcase]
+    end
   end
 end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -44,22 +44,6 @@ class Measured::Measurable < Numeric
     end
   end
 
-  class << self
-    extend Forwardable
-
-    def unit_system
-      raise "`Measurable` does not have a `unit_system` object. You cannot directly subclass `Measurable`. Instead, build a new unit system by calling `Measured.build`."
-    end
-
-    delegate unit_names: :unit_system
-    delegate unit_names_with_aliases: :unit_system
-    delegate unit_or_alias?: :unit_system
-
-    def name
-      to_s.split("::").last.underscore.humanize.downcase
-    end
-  end
-
   private
 
   def unit_from_unit_or_name!(value)

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -1,12 +1,13 @@
 class Measured::Measurable < Numeric
   include Measured::Arithmetic
 
-  attr_reader :unit, :value
+  attr_reader :unit, :value, :unit_system
 
-  def initialize(value, unit)
+  def initialize(value, unit, unit_system)
     raise Measured::UnitError, "Unit value cannot be blank" if value.blank?
 
     @unit = unit_from_unit_or_name!(unit)
+    @unit_system = unit_system
     @value = case value
     when Float
       BigDecimal(value, Float::DIG + 1)
@@ -33,7 +34,7 @@ class Measured::Measurable < Numeric
   end
 
   def inspect
-    @inspect ||= "#<#{self.class}: #{value_string} #{unit}>"
+    @inspect ||= "#<#{unit_system}: #{value_string} #{unit}>"
   end
 
   def <=>(other)

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -1,55 +1,55 @@
 class Measured::UnitSystem
-  attr_reader :units
+  class << self
+    def units
+      raise "`UnitSystem` does not have a `units` object. You cannot directly subclass `UnitSystem`. Instead, build a new unit system by calling `Measured.build`."
+    end
 
-  def initialize(units)
-    @units = units.map { |unit| unit.with_unit_system(self) }
-  end
+    def unit_names_with_aliases
+      @unit_names_with_aliases ||= units.flat_map(&:names).sort
+    end
 
-  def unit_names_with_aliases
-    @unit_names_with_aliases ||= @units.flat_map(&:names).sort
-  end
+    def unit_names
+      @unit_names ||= units.map(&:name).sort
+    end
 
-  def unit_names
-    @unit_names ||= @units.map(&:name).sort
-  end
+    def unit_or_alias?(name)
+      !!unit_for(name)
+    end
 
-  def unit_or_alias?(name)
-    !!unit_for(name)
-  end
+    def unit?(name)
+      unit = unit_for(name)
+      unit ? unit.name == name.to_s : false
+    end
 
-  def unit?(name)
-    unit = unit_for(name)
-    unit ? unit.name == name.to_s : false
-  end
+    def unit_for(name)
+      unit_name_to_unit[name.to_s]
+    end
 
-  def unit_for(name)
-    unit_name_to_unit[name.to_s]
-  end
+    def unit_for!(name)
+      unit = unit_for(name)
+      raise Measured::UnitError, "Unit '#{name}' does not exist" unless unit
+      unit
+    end
 
-  def unit_for!(name)
-    unit = unit_for(name)
-    raise Measured::UnitError, "Unit '#{name}' does not exist" unless unit
-    unit
-  end
+    def convert(value, from:, to:)
+      conversion = conversion_table.fetch(from.name, {})[to.name]
 
-  def convert(value, from:, to:)
-    conversion = conversion_table.fetch(from.name, {})[to.name]
+      raise Measured::UnitError, "Cannot find conversion entry from #{from} to #{to}" unless conversion
 
-    raise Measured::UnitError, "Cannot find conversion entry from #{from} to #{to}" unless conversion
+      value.to_r * conversion
+    end
 
-    value.to_r * conversion
-  end
+    protected
 
-  protected
+    def conversion_table
+      @conversion_table ||= Measured::ConversionTable.build(units)
+    end
 
-  def conversion_table
-    @conversion_table ||= Measured::ConversionTable.build(@units)
-  end
-
-  def unit_name_to_unit
-    @unit_name_to_unit ||= @units.inject({}) do |hash, unit|
-      unit.names.each { |name| hash[name.to_s] = unit }
-      hash
+    def unit_name_to_unit
+      @unit_name_to_unit ||= units.inject({}) do |hash, unit|
+        unit.names.each { |name| hash[name.to_s] = unit }
+        hash
+      end
     end
   end
 end

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -39,6 +39,10 @@ class Measured::UnitSystem
       value.to_r * conversion
     end
 
+    def name
+      to_s.split("::").last.underscore.humanize.downcase
+    end
+
     protected
 
     def conversion_table

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -5,7 +5,7 @@ class Measured::UnitSystem
     end
 
     def new(value, unit)
-      Measured::Measurable.new(value, unit, self)
+      Measured::Measurable.new(value, unit_from_unit_or_name!(unit))
     end
 
     def unit_names_with_aliases
@@ -33,6 +33,10 @@ class Measured::UnitSystem
       unit = unit_for(name)
       raise Measured::UnitError, "Unit '#{name}' does not exist" unless unit
       unit
+    end
+
+    def unit_from_unit_or_name!(value)
+      value.is_a?(Measured::Unit) ? value : unit_for!(value)
     end
 
     def convert(value, from:, to:)

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -4,6 +4,10 @@ class Measured::UnitSystem
       raise "`UnitSystem` does not have a `units` object. You cannot directly subclass `UnitSystem`. Instead, build a new unit system by calling `Measured.build`."
     end
 
+    def new(value, unit)
+      Measured::Measurable.new(value, unit, self)
+    end
+
     def unit_names_with_aliases
       @unit_names_with_aliases ||= units.flat_map(&:names).sort
     end

--- a/lib/measured/unit_system_builder.rb
+++ b/lib/measured/unit_system_builder.rb
@@ -10,7 +10,13 @@ class Measured::UnitSystemBuilder
   end
 
   def build
-    unit_system_class.new(@units)
+    clazz = Class.new(unit_system_class) do
+      class << self
+        attr_reader :units
+      end
+    end
+    clazz.instance_variable_set(:@units, @units.map { |unit| unit.with_unit_system(clazz) })
+    clazz
   end
 
   private

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -89,6 +89,12 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     assert_equal [@two, @three], @three.coerce(@two)
   end
 
+  test "#coerce should raise TypeError when trying to coerce Measurables in two different unit systems" do
+    exception = assert_raises(TypeError) { @two.coerce(CaseSensitiveMagic.new(1, :magic_missile)) }
+
+    assert_equal "Cannot coerce 'case sensitive magic' values to 'magic'", exception.message
+  end
+
   test "#coerce should raise TypeError when other cannot be coerced" do
     assert_raises(TypeError) { @two.coerce(2) }
     assert_raises(TypeError) { @three.coerce(5.2) }

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -79,7 +79,7 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
   test "arithmetic operations favours unit of left" do
     left = Magic.new(1, :arcane)
     right = Magic.new(1, :magic_missile)
-    arcane = Magic.unit_system.unit_for!(:arcane)
+    arcane = Magic.unit_for!(:arcane)
 
     assert_equal arcane, (left + right).unit
     assert_equal arcane, (left - right).unit

--- a/test/case_insensitive_unit_system_test.rb
+++ b/test/case_insensitive_unit_system_test.rb
@@ -2,12 +2,18 @@ require "test_helper"
 
 class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
   setup do
-    @unit_fireball = Magic.unit_system.unit_for!(:fireball)
+    @unit_fireball = Magic.unit_for!(:fireball)
 
     @unit_m = Measured::CaseInsensitiveUnit.new(:m)
     @unit_in = Measured::CaseInsensitiveUnit.new(:in, aliases: [:inch], value: "0.0254 m")
     @unit_ft = Measured::CaseInsensitiveUnit.new(:ft, aliases: [:feet, :foot], value: "0.3048 m")
-    @conversion = Measured::CaseInsensitiveUnitSystem.new([@unit_m, @unit_in, @unit_ft])
+
+    @conversion = Class.new(Measured::CaseInsensitiveUnitSystem) do
+      class << self
+        attr_reader :units
+      end
+    end
+    @conversion.instance_variable_set(:@units, [@unit_m, @unit_in, @unit_ft])
   end
 
   test "#unit_names_with_aliases lists all allowed unit names" do
@@ -45,36 +51,36 @@ class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
   end
 
   test "#unit_for converts a unit name to its base unit" do
-    assert_equal @unit_fireball, Magic.unit_system.unit_for("fire")
+    assert_equal @unit_fireball, Magic.unit_for("fire")
   end
 
   test "#unit_for does not care about string or symbol" do
-    assert_equal @unit_fireball, Magic.unit_system.unit_for(:fire)
+    assert_equal @unit_fireball, Magic.unit_for(:fire)
   end
 
   test "#unit_for passes through if already base unit name" do
-    assert_equal @unit_fireball, Magic.unit_system.unit_for("fireball")
+    assert_equal @unit_fireball, Magic.unit_for("fireball")
   end
 
   test "#unit_for returns nil if not found" do
-    assert_nil Magic.unit_system.unit_for("thunder")
+    assert_nil Magic.unit_for("thunder")
   end
 
   test "#unit_for! converts a unit name to its base unit" do
-    assert_equal @unit_fireball, Magic.unit_system.unit_for!("fire")
+    assert_equal @unit_fireball, Magic.unit_for!("fire")
   end
 
   test "#unit_for! does not care about string or symbol" do
-    assert_equal @unit_fireball, Magic.unit_system.unit_for!(:fire)
+    assert_equal @unit_fireball, Magic.unit_for!(:fire)
   end
 
   test "#unit_for! passes through if already base unit name" do
-    assert_equal @unit_fireball, Magic.unit_system.unit_for!("fireball")
+    assert_equal @unit_fireball, Magic.unit_for!("fireball")
   end
 
   test "#unit_for! raises if not found" do
     assert_raises_with_message(Measured::UnitError, "Unit 'thunder' does not exist") do
-      Magic.unit_system.unit_for!("thunder")
+      Magic.unit_for!("thunder")
     end
   end
 
@@ -82,11 +88,11 @@ class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
     unit_bad = Measured::Unit.new(:doesnt_exist)
 
     assert_raises Measured::UnitError do
-      Magic.unit_system.convert(1, from: @unit_fireball, to: unit_bad)
+      Magic.convert(1, from: @unit_fireball, to: unit_bad)
     end
 
     assert_raises Measured::UnitError do
-      Magic.unit_system.convert(1, from: unit_bad, to: @unit_fireball)
+      Magic.convert(1, from: unit_bad, to: @unit_fireball)
     end
   end
 

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -85,13 +85,6 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal BigDecimal(10), @magic.value
   end
 
-  test ".conversion is set and cached" do
-    conversion = CaseSensitiveMagic
-
-    assert_instance_of Measured::UnitSystem, conversion
-    assert_equal conversion.__id__, CaseSensitiveMagic.__id__
-  end
-
   test ".unit_names returns just the base unit names" do
     assert_equal %w(arcane fireball ice magic_missile ultima), Magic.unit_names
   end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -3,9 +3,9 @@ require "test_helper"
 class Measured::MeasurableTest < ActiveSupport::TestCase
 
   setup do
-    @arcane = Magic.unit_system.unit_for!(:arcane)
-    @fireball = Magic.unit_system.unit_for!(:fireball)
-    @magic_missile = Magic.unit_system.unit_for!(:magic_missile)
+    @arcane = Magic.unit_for!(:arcane)
+    @fireball = Magic.unit_for!(:fireball)
+    @magic_missile = Magic.unit_for!(:magic_missile)
     @magic = Magic.new(10, @magic_missile)
   end
 
@@ -86,10 +86,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test ".conversion is set and cached" do
-    conversion = CaseSensitiveMagic.unit_system
+    conversion = CaseSensitiveMagic
 
     assert_instance_of Measured::UnitSystem, conversion
-    assert_equal conversion.__id__, CaseSensitiveMagic.unit_system.__id__
+    assert_equal conversion.__id__, CaseSensitiveMagic.__id__
   end
 
   test ".unit_names returns just the base unit names" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
-    to_unit = klass.unit_system.unit_for!(to_unit)
+    to_unit = klass.unit_for!(to_unit)
     assert_close_bigdecimal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 
@@ -31,7 +31,7 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
-    to_unit = klass.unit_system.unit_for!(to_unit)
+    to_unit = klass.unit_for!(to_unit)
     assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,6 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
-    to_unit = klass.unit_for!(to_unit)
     assert_close_bigdecimal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 
@@ -31,7 +30,6 @@ class ActiveSupport::TestCase
     from_amount, from_unit = from.split(" ")
     to_amount, to_unit = to.split(" ")
 
-    to_unit = klass.unit_for!(to_unit)
     assert_equal BigDecimal(to_amount), klass.new(from_amount, from_unit).convert_to(to_unit).value
   end
 

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -43,7 +43,7 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
       unit :BOLD, value: "100 normal"
     end
 
-    assert_equal 'BOLD', measurable.unit_system.unit_for!(:BOLD).name
+    assert_equal 'BOLD', measurable.unit_for!(:BOLD).name
   end
 
   test "case-insensitive conversion is produced by default" do
@@ -53,6 +53,6 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
       unit :bolder, value: "100 normal"
     end
 
-    assert_equal 'bold', measurable.unit_system.unit_for!(:bOlD).name
+    assert_equal 'bold', measurable.unit_for!(:bOlD).name
   end
 end

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -2,12 +2,12 @@ require "test_helper"
 
 class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
   test "#unit adds a new unit" do
-    measurable = Measured.build do
+    unit_system = Measured.build do
       unit :m
       unit :in, aliases: [:inch], value: "0.0254 m"
     end
 
-    assert_equal 2, measurable.unit_names.count
+    assert_equal 2, unit_system.unit_names.count
   end
 
   test "#unit cannot add duplicate unit names" do
@@ -36,23 +36,25 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
     end
   end
 
-  test "#case_sensitive true produces a case-sensitive conversion" do
-    measurable = Measured.build(case_sensitive: true) do
+  test ".build with case_sensitive: true produces a case-sensitive unit system" do
+    unit_system = Measured.build(case_sensitive: true) do
       unit :normal
       unit :bold, value: "10 normal"
       unit :BOLD, value: "100 normal"
     end
 
-    assert_equal 'BOLD', measurable.unit_for!(:BOLD).name
+    assert_equal Measured::UnitSystem, unit_system.superclass
+    assert_equal 'BOLD', unit_system.unit_for!(:BOLD).name
   end
 
-  test "case-insensitive conversion is produced by default" do
-    measurable = Measured.build(case_sensitive: false) do
+  test ".build produces case-insensitive unit system by default" do
+    unit_system = Measured.build(case_sensitive: false) do
       unit :normal
       unit :bold, value: "10 normal"
       unit :bolder, value: "100 normal"
     end
 
-    assert_equal 'bold', measurable.unit_for!(:bOlD).name
+    assert_equal Measured::CaseInsensitiveUnitSystem, unit_system.superclass
+    assert_equal 'bold', unit_system.unit_for!(:bOlD).name
   end
 end

--- a/test/unit_system_test.rb
+++ b/test/unit_system_test.rb
@@ -2,12 +2,18 @@ require "test_helper"
 
 class Measured::UnitSystemTest < ActiveSupport::TestCase
   setup do
-    @unit_fireball = CaseSensitiveMagic.unit_system.unit_for!(:fireball)
+    @unit_fireball = CaseSensitiveMagic.unit_for!(:fireball)
 
     @unit_m = Measured::Unit.new(:m)
     @unit_in = Measured::Unit.new(:in, aliases: [:Inch], value: "0.0254 m")
     @unit_ft = Measured::Unit.new(:ft, aliases: [:Feet, :Foot], value: "0.3048 m")
-    @conversion = Measured::UnitSystem.new([@unit_m, @unit_in, @unit_ft])
+
+    @conversion = Class.new(Measured::UnitSystem) do
+      class << self
+        attr_reader :units
+      end
+    end
+    @conversion.instance_variable_set(:@units, [@unit_m, @unit_in, @unit_ft])
   end
 
   test "#unit_names_with_aliases lists all allowed unit names" do
@@ -46,36 +52,36 @@ class Measured::UnitSystemTest < ActiveSupport::TestCase
   end
 
   test "#unit_for converts a unit name to its base unit" do
-    assert_equal @unit_fireball, CaseSensitiveMagic.unit_system.unit_for("fire")
+    assert_equal @unit_fireball, CaseSensitiveMagic.unit_for("fire")
   end
 
   test "#unit_for does not care about string or symbol" do
-    assert_equal @unit_fireball, CaseSensitiveMagic.unit_system.unit_for(:fire)
+    assert_equal @unit_fireball, CaseSensitiveMagic.unit_for(:fire)
   end
 
   test "#unit_for passes through if already base unit name" do
-    assert_equal @unit_fireball, CaseSensitiveMagic.unit_system.unit_for("fireball")
+    assert_equal @unit_fireball, CaseSensitiveMagic.unit_for("fireball")
   end
 
   test "#unit_for returns nil if not found" do
-    assert_nil CaseSensitiveMagic.unit_system.unit_for("thunder")
+    assert_nil CaseSensitiveMagic.unit_for("thunder")
   end
 
   test "#unit_for! converts a unit name to its base unit" do
-    assert_equal @unit_fireball, CaseSensitiveMagic.unit_system.unit_for!("fire")
+    assert_equal @unit_fireball, CaseSensitiveMagic.unit_for!("fire")
   end
 
   test "#unit_for! does not care about string or symbol" do
-    assert_equal @unit_fireball, CaseSensitiveMagic.unit_system.unit_for!(:fire)
+    assert_equal @unit_fireball, CaseSensitiveMagic.unit_for!(:fire)
   end
 
   test "#unit_for! passes through if already base unit name" do
-    assert_equal @unit_fireball, CaseSensitiveMagic.unit_system.unit_for!("fireball")
+    assert_equal @unit_fireball, CaseSensitiveMagic.unit_for!("fireball")
   end
 
   test "#unit_for! raises if not found" do
     assert_raises_with_message(Measured::UnitError, "Unit 'thunder' does not exist") do
-      CaseSensitiveMagic.unit_system.unit_for!("thunder")
+      CaseSensitiveMagic.unit_for!("thunder")
     end
   end
 
@@ -83,11 +89,11 @@ class Measured::UnitSystemTest < ActiveSupport::TestCase
     unit_bad = Measured::Unit.new(:doesnt_exist)
 
     assert_raises Measured::UnitError do
-      CaseSensitiveMagic.unit_system.convert(1, from: @unit_fireball, to: unit_bad)
+      CaseSensitiveMagic.convert(1, from: @unit_fireball, to: unit_bad)
     end
 
     assert_raises Measured::UnitError do
-      CaseSensitiveMagic.unit_system.convert(1, from: unit_bad, to: @unit_fireball)
+      CaseSensitiveMagic.convert(1, from: unit_bad, to: @unit_fireball)
     end
   end
 


### PR DESCRIPTION
One of the last big changes to make before Measured 2.0, `Measured.build` will now return a dynamically-defined subclass of `UnitSystem` instead of `Measurable`. Adds a little complexity in some places, but I think the semantics of building a unit system make more sense than a measurable subclass that has class method pointing to the unit system.

Recommend adding `w=1` to the query string. Additional comments in line.

Will switch to merging into master after https://github.com/Shopify/measured/pull/70 merged.