### PR TITLE
Store the unit system in Unit instances

### DIFF
--- a/lib/measured/case_insensitive_unit.rb
+++ b/lib/measured/case_insensitive_unit.rb
@@ -1,5 +1,5 @@
 class Measured::CaseInsensitiveUnit < Measured::Unit
-  def initialize(name, aliases: [], value: nil)
-    super(name.to_s.downcase, aliases: aliases.map(&:to_s).map!(&:downcase), value: value)
+  def initialize(name, aliases: [], value: nil, unit_system: nil)
+    super(name.to_s.downcase, aliases: aliases.map(&:to_s).map!(&:downcase), value: value, unit_system: unit_system)
   end
 end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -23,9 +23,9 @@ class Measured::Measurable < Numeric
     new_unit = unit_from_unit_or_name!(new_unit)
     return self if new_unit == unit
 
-    value = self.class.unit_system.convert(self.value, from: unit, to: new_unit)
+    new_value = unit.unit_system.convert(value, from: unit, to: new_unit)
 
-    self.class.new(value, new_unit)
+    self.class.new(new_value, new_unit)
   end
 
   def to_s

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -1,12 +1,22 @@
 class Measured::Unit
   include Comparable
 
-  attr_reader :name, :names, :conversion_amount, :conversion_unit
+  attr_reader :name, :names, :conversion_amount, :conversion_unit, :unit_system
 
-  def initialize(name, aliases: [], value: nil)
+  def initialize(name, aliases: [], value: nil, unit_system: nil)
     @name = name.to_s
     @names = ([@name] + aliases.map(&:to_s)).sort
     @conversion_amount, @conversion_unit = parse_value(value) if value
+    @unit_system = unit_system
+  end
+
+  def with_unit_system(unit_system)
+    self.class.new(
+      name,
+      aliases: names - [name],
+      value: conversion_string,
+      unit_system: unit_system
+    )
   end
 
   def to_s

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -2,7 +2,7 @@ class Measured::UnitSystem
   attr_reader :units
 
   def initialize(units)
-    @units = units.dup
+    @units = units.map { |unit| unit.with_unit_system(self) }
   end
 
   def unit_names_with_aliases

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -3,10 +3,10 @@ require "test_helper"
 class Measured::MeasurableTest < ActiveSupport::TestCase
 
   setup do
-    @magic = Magic.new(10, :magic_missile)
     @arcane = Magic.unit_system.unit_for!(:arcane)
     @fireball = Magic.unit_system.unit_for!(:fireball)
     @magic_missile = Magic.unit_system.unit_for!(:magic_missile)
+    @magic = Magic.new(10, @magic_missile)
   end
 
   test "#initialize requires two params, the amount and the unit" do


### PR DESCRIPTION
It makes sense for `Unit` instances to know what system they're in. Technically, we could have units that are the same between two systems (e.g., case-sensitive and case-insensitive systems, metric/imperial, some other weird thing with magic missiles in different video games) in which case this will allow distinguishing them.

Primarily, this will simplify https://github.com/Shopify/measured/pull/71 a fair bit by removing the need to pass in a unit system to `Measurable#initialize`.