### PR TITLE
Tidy up and simplify unit tests

### DIFF
--- a/test/case_insensitive_unit_system_test.rb
+++ b/test/case_insensitive_unit_system_test.rb
@@ -6,16 +6,16 @@ class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
 
     @unit_m = Measured::CaseInsensitiveUnit.new(:m)
     @unit_in = Measured::CaseInsensitiveUnit.new(:in, aliases: [:inch], value: "0.0254 m")
-    @unit_ft = Measured::CaseInsensitiveUnit.new(:ft, aliases: [:feet, :foot], value: "0.3048 m")
+    @unit_ft = Measured::CaseInsensitiveUnit.new(:ft, aliases: %w(Feet FOOT), value: "0.3048 m")
     @conversion = Measured::CaseInsensitiveUnitSystem.new([@unit_m, @unit_in, @unit_ft])
   end
 
-  test "#unit_names_with_aliases lists all allowed unit names" do
-    assert_equal ["feet", "foot", "ft", "in", "inch", "m"], @conversion.unit_names_with_aliases
+  test "#unit_names_with_aliases lists all allowed unit names in lowercase" do
+    assert_equal %w(feet foot ft in inch m), @conversion.unit_names_with_aliases
   end
 
-  test "#unit_names lists all base unit names without aliases" do
-    assert_equal ["ft", "in", "m"], @conversion.unit_names
+  test "#unit_names lists all base unit names without aliases in lowercase" do
+    assert_equal %w(ft in m), @conversion.unit_names
   end
 
   test "#unit? checks if the unit is part of the units but not aliases" do
@@ -91,11 +91,11 @@ class Measured::CaseInsensitiveUnitSystemTest < ActiveSupport::TestCase
   end
 
   test "#convert converts between two known units" do
-    assert_equal BigDecimal("3"), @conversion.convert(BigDecimal("36"), from: @unit_in, to: @unit_ft)
-    assert_equal BigDecimal("18"), @conversion.convert(BigDecimal("1.5"), from: @unit_ft, to: @unit_in)
+    assert_equal 3, @conversion.convert(36, from: @unit_in, to: @unit_ft)
+    assert_equal 18, @conversion.convert(Rational(3, 2), from: @unit_ft, to: @unit_in)
   end
 
   test "#convert handles the same unit" do
-    assert_equal BigDecimal("2"), @conversion.convert(BigDecimal("2"), from: @unit_in, to: @unit_in)
+    assert_equal 2, @conversion.convert(2, from: @unit_in, to: @unit_in)
   end
 end

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
   setup do
     @unit = Measured::CaseInsensitiveUnit.new(:Pie, value: "10 Cake")
-    @unit_with_aliases = Measured::CaseInsensitiveUnit.new(:Pie, aliases: ["Cake", "Tart"])
+    @unit_with_aliases = Measured::CaseInsensitiveUnit.new(:Pie, aliases: %w(Cake Tart))
   end
 
   test "#initialize converts the name to a downcased string" do
@@ -15,7 +15,7 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
   end
 
   test "#initialize parses out the unit and the number part" do
-    assert_equal BigDecimal(10), @unit.conversion_amount
+    assert_equal 10, @unit.conversion_amount
     assert_equal "Cake", @unit.conversion_unit
 
     unit = Measured::CaseInsensitiveUnit.new(:pie, value: "5.5 sweets")
@@ -39,12 +39,12 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
 
   test "#to_s returns an expected string" do
     assert_equal "pie", Measured::CaseInsensitiveUnit.new(:pie).to_s
-    assert_equal "pie (1/2 sweet)", Measured::CaseInsensitiveUnit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).to_s
+    assert_equal "pie (1/2 sweet)", Measured::CaseInsensitiveUnit.new(:pie, aliases: ["cake"], value: "0.5 sweet").to_s
   end
 
   test "#inspect returns an expected string" do
     assert_equal "#<Measured::Unit: pie (pie) >", Measured::CaseInsensitiveUnit.new(:pie).inspect
-    assert_equal "#<Measured::Unit: pie (cake, pie) 1/2 sweet>", Measured::CaseInsensitiveUnit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).inspect
+    assert_equal "#<Measured::Unit: pie (cake, pie) 1/2 sweet>", Measured::CaseInsensitiveUnit.new(:pie, aliases: ["cake"], value: "1/2 sweet").inspect
   end
 
   test "includes Comparable mixin" do
@@ -73,12 +73,7 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
     assert_equal 1, @unit <=> Measured::CaseInsensitiveUnit.new(:pie, value: [9, :pancake])
   end
 
-  test "#inverse_conversion_amount returns 1/amount for BigDecimal" do
-    assert_equal BigDecimal(1) / 10, @unit.inverse_conversion_amount
-  end
-
-  test "#inverse_conversion_amount swaps the numerator and denominator for Rational" do
-    unit = Measured::CaseInsensitiveUnit.new(:pie, value: [Rational(3, 7), "cake"])
-    assert_equal Rational(7, 3), unit.inverse_conversion_amount
+  test "#inverse_conversion_amount returns 1/amount" do
+    assert_equal Rational(1, 10), @unit.inverse_conversion_amount
   end
 end

--- a/test/unit_system_test.rb
+++ b/test/unit_system_test.rb
@@ -6,16 +6,16 @@ class Measured::UnitSystemTest < ActiveSupport::TestCase
 
     @unit_m = Measured::Unit.new(:m)
     @unit_in = Measured::Unit.new(:in, aliases: [:Inch], value: "0.0254 m")
-    @unit_ft = Measured::Unit.new(:ft, aliases: [:Feet, :Foot], value: "0.3048 m")
+    @unit_ft = Measured::Unit.new(:ft, aliases: %w(Feet Foot), value: "0.3048 m")
     @conversion = Measured::UnitSystem.new([@unit_m, @unit_in, @unit_ft])
   end
 
   test "#unit_names_with_aliases lists all allowed unit names" do
-    assert_equal ["Feet", "Foot", "Inch", "ft", "in", "m"], @conversion.unit_names_with_aliases
+    assert_equal %w(Feet Foot Inch ft in m), @conversion.unit_names_with_aliases
   end
 
   test "#unit_names lists all unit names without aliases" do
-    assert_equal ["ft", "in", "m"], @conversion.unit_names
+    assert_equal %w(ft in m), @conversion.unit_names
   end
 
   test "#unit? checks if the unit is part of the units but not aliases" do
@@ -92,11 +92,11 @@ class Measured::UnitSystemTest < ActiveSupport::TestCase
   end
 
   test "#convert converts between two known units" do
-    assert_equal BigDecimal("3"), @conversion.convert(BigDecimal("36"), from: @unit_in, to: @unit_ft)
-    assert_equal BigDecimal("18"), @conversion.convert(BigDecimal("1.5"), from: @unit_ft, to: @unit_in)
+    assert_equal 3, @conversion.convert(36, from: @unit_in, to: @unit_ft)
+    assert_equal 18, @conversion.convert(Rational(3, 2), from: @unit_ft, to: @unit_in)
   end
 
   test "#convert handles the same unit" do
-    assert_equal BigDecimal("2"), @conversion.convert(BigDecimal("2"), from: @unit_in, to: @unit_in)
+    assert_equal 2, @conversion.convert(2, from: @unit_in, to: @unit_in)
   end
 end

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -3,7 +3,7 @@ require "test_helper"
 class Measured::UnitTest < ActiveSupport::TestCase
   setup do
     @unit = Measured::Unit.new(:Pie, value: "10 Cake")
-    @unit_with_aliases = Measured::Unit.new(:Pie, aliases: ["Cake", "Tart"])
+    @unit_with_aliases = Measured::Unit.new(:Pie, aliases: %w(Cake Tart))
   end
 
   test "#initialize converts the name to a string" do
@@ -15,7 +15,7 @@ class Measured::UnitTest < ActiveSupport::TestCase
   end
 
   test "#initialize parses out the unit and the number part" do
-    assert_equal BigDecimal(10), @unit.conversion_amount
+    assert_equal 10, @unit.conversion_amount
     assert_equal "Cake", @unit.conversion_unit
 
     unit = Measured::Unit.new(:pie, value: "5.5 sweets")
@@ -39,12 +39,12 @@ class Measured::UnitTest < ActiveSupport::TestCase
 
   test "#to_s returns an expected string" do
     assert_equal "pie", Measured::Unit.new(:pie).to_s
-    assert_equal "pie (1/2 sweet)", Measured::Unit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).to_s
+    assert_equal "pie (1/2 sweet)", Measured::Unit.new(:pie, aliases: ["cake"], value: "0.5 sweet").to_s
   end
 
   test "#inspect returns an expected string" do
     assert_equal "#<Measured::Unit: pie (pie) >", Measured::Unit.new(:pie).inspect
-    assert_equal "#<Measured::Unit: pie (cake, pie) 1/2 sweet>", Measured::Unit.new(:pie, aliases: ["cake"], value: [Rational(1,2), "sweet"]).inspect
+    assert_equal "#<Measured::Unit: pie (cake, pie) 1/2 sweet>", Measured::Unit.new(:pie, aliases: ["cake"], value: "1/2 sweet").inspect
   end
 
   test "includes Comparable mixin" do
@@ -73,12 +73,7 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal 1, @unit <=> Measured::Unit.new(:Pie, value: [9, :pancake])
   end
 
-  test "#inverse_conversion_amount returns 1/amount for BigDecimal" do
-    assert_equal BigDecimal(1) / 10, @unit.inverse_conversion_amount
-  end
-
-  test "#inverse_conversion_amount swaps the numerator and denominator for Rational" do
-    unit = Measured::Unit.new(:pie, value: [Rational(3, 7), "cake"])
-    assert_equal Rational(7, 3), unit.inverse_conversion_amount
+  test "#inverse_conversion_amount returns 1/amount" do
+    assert_equal Rational(1, 10), @unit.inverse_conversion_amount
   end
 end


### PR DESCRIPTION
Highlights:

* Improving data used in case-insensitive tests
* Preferring `value: "x/y unit"` over `value: [Rational(x, y), :unit]` when not testing `#initialize`
* `%w`-style lists
* Not using `BigDecimal` anywhere where a `Rational` or `Integer` is fine