### PR TITLE
Also downcase conversion unit for CaseInsensitiveUnit

### DIFF
--- a/lib/measured/case_insensitive_unit.rb
+++ b/lib/measured/case_insensitive_unit.rb
@@ -1,5 +1,17 @@
 class Measured::CaseInsensitiveUnit < Measured::Unit
   def initialize(name, aliases: [], value: nil, unit_system: nil)
-    super(name.to_s.downcase, aliases: aliases.map(&:to_s).map!(&:downcase), value: value, unit_system: unit_system)
+    super(
+      name.to_s.downcase,
+      aliases: aliases.map(&:to_s).map!(&:downcase),
+      value: value,
+      unit_system: unit_system
+    )
+  end
+
+  private
+
+  def parse_value(tokens)
+    value, unit = super
+    [value, unit.downcase]
   end
 end

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -16,7 +16,7 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
 
   test "#initialize parses out the unit and the number part" do
     assert_equal 10, @unit.conversion_amount
-    assert_equal "Cake", @unit.conversion_unit
+    assert_equal "cake", @unit.conversion_unit
 
     unit = Measured::CaseInsensitiveUnit.new(:pie, value: "5.5 sweets")
     assert_equal BigDecimal("5.5"), unit.conversion_amount


### PR DESCRIPTION
We `downcase` everything else, so this was a discrepancy which I would even call a bug.

The conversion unit wasn't actually used in any comparison operations, so this doesn't actually change any internal behaviour, and since `CaseInsensitiveUnit` is a concept that was introduced for 2.0, doesn't break any client of the library except those using the prereleases.