### PR TITLE
Allow multiple words for the conversion unit

### DIFF
--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -55,7 +55,7 @@ class Measured::Unit
   end
 
   def parse_value(tokens)
-    tokens = tokens.split(" ") if tokens.is_a?(String)
+    tokens = tokens.split(" ", 2) if tokens.is_a?(String)
 
     raise Measured::UnitError, "Cannot parse 'number unit' or [number, unit] formatted tokens from #{tokens}." unless tokens.size == 2
 

--- a/test/case_insensitive_unit_test.rb
+++ b/test/case_insensitive_unit_test.rb
@@ -21,15 +21,15 @@ class Measured::CaseInsensitiveUnitTest < ActiveSupport::TestCase
     unit = Measured::CaseInsensitiveUnit.new(:pie, value: "5.5 sweets")
     assert_equal BigDecimal("5.5"), unit.conversion_amount
     assert_equal "sweets", unit.conversion_unit
+
+    unit = Measured::CaseInsensitiveUnit.new(:pie, value: "1/3 Bitter Pies")
+    assert_equal Rational(1, 3), unit.conversion_amount
+    assert_equal "bitter pies", unit.conversion_unit
   end
 
   test "#initialize raises if the format of the value is incorrect" do
     assert_raises Measured::UnitError do
       Measured::CaseInsensitiveUnit.new(:pie, value: "hello")
-    end
-
-    assert_raises Measured::UnitError do
-      Measured::CaseInsensitiveUnit.new(:pie, value: "pie is delicious")
     end
 
     assert_raises Measured::UnitError do

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -18,18 +18,18 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal 10, @unit.conversion_amount
     assert_equal "Cake", @unit.conversion_unit
 
-    unit = Measured::Unit.new(:pie, value: "5.5 sweets")
+    unit = Measured::Unit.new(:pie, value: ["5.5", "sweets"])
     assert_equal BigDecimal("5.5"), unit.conversion_amount
     assert_equal "sweets", unit.conversion_unit
+
+    unit = Measured::Unit.new(:pie, value: "1/3 bitter pie")
+    assert_equal Rational(1, 3), unit.conversion_amount
+    assert_equal "bitter pie", unit.conversion_unit
   end
 
   test "#initialize raises if the format of the value is incorrect" do
     assert_raises Measured::UnitError do
       Measured::Unit.new(:pie, value: "hello")
-    end
-
-    assert_raises Measured::UnitError do
-      Measured::Unit.new(:pie, value: "pie is delicious")
     end
 
     assert_raises Measured::UnitError do


### PR DESCRIPTION
There are units that are more than one word, so we should have an interface that allows specifying these via conversion strings in units. In other words, we should support the following:

```ruby
Length = Measured.build do
  unit :m, value: "1/1852 nautical miles"
end
```