### PR TITLE
Allow .parse to load from string

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,20 @@ rescue Measured::UnitError
 end
 ```
 
+Parse from string without having to split out the value and unit first:
+
+```ruby
+Measured::Weight.parse("123 grams")
+> #<Measured::Weight 123 g>
+```
+
+Parse can scrub extra whitespace and split number from unit:
+
+```ruby
+Measured::Weight.parse(" 2kg ")
+> #<Measured::Weight 2 kg>
+```
+
 Perform addition / subtraction against other units, all represented internally as `Rational` or `BigDecimal`:
 
 ```ruby

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -38,6 +38,7 @@ module Measured
 end
 
 require "measured/arithmetic"
+require "measured/parser"
 require "measured/unit"
 require "measured/unit_system"
 require "measured/unit_system_builder"

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -1,26 +1,6 @@
 class Measured::Measurable < Numeric
   include Measured::Arithmetic
 
-  PARSE_REGEX = /
-    \A         # beginning of input
-    \s*        # optionally any whitespace
-    (          # capture the value
-      -?       # number can be negative
-      \d+      # must have some digits
-      (?:      # do not capture
-        \.     # period to split fractional part
-        \d+    # some digits after it
-      )?       # fractional part is optional
-    )
-    \s*        # optionally any space between number and unit
-    (          # capture the unit
-      [\w\s-]  # any word or space or dash to
-      +?       # capture it lazily to not take trailing whitespace
-    )
-    \s*        # optionally any whitespace
-    \Z         # end of unit
-  /x
-
   attr_reader :unit, :value
 
   def initialize(value, unit)
@@ -87,13 +67,7 @@ class Measured::Measurable < Numeric
     end
 
     def parse(string)
-      raise Measured::UnitError, "Cannot parse blank measurement" if string.blank?
-
-      result = PARSE_REGEX.match(string)
-
-      raise Measured::UnitError, "Cannot parse measurement" unless result
-
-      new(*result.captures)
+      new(*Measured::Parser.parse_string(string))
     end
   end
 

--- a/lib/measured/parser.rb
+++ b/lib/measured/parser.rb
@@ -1,0 +1,37 @@
+module Measured::Parser
+  extend self
+
+  PARSE_REGEX = /
+    \A         # beginning of input
+    \s*        # optionally any whitespace
+    (          # capture the value
+      -?       # number can be negative
+      \d+      # must have some digits
+      (?:      # do not capture
+        [\.\/] # period or slash to split fractional part
+        \d+    # some digits after it
+      )?       # fractional part is optional
+    )
+    \s*        # optionally any space between number and unit
+    (          # capture the unit
+      [a-zA-Z] # unit must start with a letter
+      [\w-]*   # any word characters or dashes
+      (?:      # non capturing group that is optional for multiple words
+        \s+    # space in the unit for multiple words
+        [\w-]+ # there must be something after the space
+      )*       # allow many words
+    )
+    \s*        # optionally any whitespace
+    \Z         # end of unit
+  /x
+
+  def parse_string(string)
+    raise Measured::UnitError, "Cannot parse blank measurement" if string.blank?
+
+    result = PARSE_REGEX.match(string)
+
+    raise Measured::UnitError, "Cannot parse measurement from '#{string}'" unless result
+
+    [result.captures[0].to_r, result.captures[1]]
+  end
+end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -64,9 +64,14 @@ class Measured::Unit
   end
 
   def parse_value(tokens)
-    tokens = tokens.split(" ", 2) if tokens.is_a?(String)
-
-    raise Measured::UnitError, "Cannot parse 'number unit' or [number, unit] formatted tokens from #{tokens}." unless tokens.size == 2
+    case tokens
+    when String
+      tokens = Measured::Parser.parse_string(tokens)
+    when Array
+      raise Measured::UnitError, "Cannot parse [number, unit] formatted tokens from #{tokens}." unless tokens.size == 2
+    else
+      raise Measured::UnitError, "Unit must be defined as string or array, but received #{tokens}"
+    end
 
     [tokens[0].to_r, tokens[1].freeze]
   end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -129,6 +129,20 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "Cannot parse blank measurement", exception.message
   end
 
+  test ".parse raises on a single incorrect string" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.parse("arcane")
+    end
+    assert_equal "Cannot parse measurement from 'arcane'", exception.message
+  end
+
+  test ".parse raises on a single incorrect number" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.parse("1234")
+    end
+    assert_equal "Cannot parse measurement from '1234'", exception.message
+  end
+
   test ".parse takes input with a space between" do
     assert_equal Magic.new(1, :arcane), Magic.parse("1 arcane")
   end
@@ -153,11 +167,15 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     exception = assert_raises(Measured::UnitError) do
       Magic.parse("12.34.56 ice")
     end
-    assert_equal "Cannot parse measurement", exception.message
+    assert_equal "Cannot parse measurement from '12.34.56 ice'", exception.message
   end
 
   test ".parse parses negative numbers" do
     assert_equal Magic.new(-12.34, :arcane), Magic.parse("-12.34 arcane")
+  end
+
+  test ".parse parses rational numbers" do
+    assert_equal Magic.new(1.5, :magic_missile), Magic.parse("3/2magic missile")
   end
 
   test ".parse raises on unknown unit" do

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -94,7 +94,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test ".unit_names_with_aliases returns all units" do
     assert_equal(
-      %w(arcane fire fireball fireballs ice magic_missile magic_missiles ultima),
+      %w(arcane fire fireball fireballs ice magic\ missile magic_missile magic_missiles ultima),
       Magic.unit_names_with_aliases
     )
   end
@@ -113,6 +113,58 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
     assert_equal "magic", Magic.name
     assert_equal "very complex thing", Example::VeryComplexThing.name
+  end
+
+  test ".parse raises on nil input" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.parse(nil)
+    end
+    assert_equal "Cannot parse blank measurement", exception.message
+  end
+
+  test ".parse raises on blank string input" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.parse("")
+    end
+    assert_equal "Cannot parse blank measurement", exception.message
+  end
+
+  test ".parse takes input with a space between" do
+    assert_equal Magic.new(1, :arcane), Magic.parse("1 arcane")
+  end
+
+  test ".parse takes input without a space" do
+    assert_equal Magic.new(99, :ice), Magic.parse("99ice")
+  end
+
+  test ".parse takes float with a space" do
+    assert_equal Magic.new(12.345, :arcane), Magic.parse("12.345 arcane")
+  end
+
+  test ".parse takes float without a space" do
+    assert_equal Magic.new(9.9, :magic_missile), Magic.parse("9.9magic_missile")
+  end
+
+  test ".parse truncates any space before and after" do
+    assert_equal Magic.new(8765, :arcane), Magic.parse("   8765     arcane    ")
+  end
+
+  test ".parse raises with multiple periods in fractional numbers" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.parse("12.34.56 ice")
+    end
+    assert_equal "Cannot parse measurement", exception.message
+  end
+
+  test ".parse parses negative numbers" do
+    assert_equal Magic.new(-12.34, :arcane), Magic.parse("-12.34 arcane")
+  end
+
+  test ".parse raises on unknown unit" do
+    exception = assert_raises(Measured::UnitError) do
+      Magic.parse("1 fake")
+    end
+    assert_equal "Unit 'fake' does not exist", exception.message
   end
 
   test "#convert_to raises on an invalid unit" do
@@ -157,7 +209,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test "#inspect shows the number and the unit" do
     assert_equal "#<Magic: 10 #<Measured::Unit: fireball (fire, fireballs) 2/3 magic_missile>>", Magic.new(10, :fire).inspect
-    assert_equal "#<Magic: 1.234 #<Measured::Unit: magic_missile (magic_missiles)>>", Magic.new(1.234, :magic_missile).inspect
+    assert_equal "#<Magic: 1.234 #<Measured::Unit: magic_missile (magic_missiles, magic missile)>>", Magic.new(1.234, :magic_missile).inspect
   end
 
   test "#zero? always returns false" do
@@ -215,5 +267,4 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_raises(ArgumentError) { @magic < BigDecimal.new(0) }
     assert_raises(ArgumentError) { @magic < 0.00 }
   end
-
 end

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,0 +1,88 @@
+require "test_helper"
+
+class Measured::ParserTest < ActiveSupport::TestCase
+  test "#parse raises on nil input" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string(nil)
+    end
+    assert_equal "Cannot parse blank measurement", exception.message
+  end
+
+  test "#parse raises on blank string input" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string("")
+    end
+    assert_equal "Cannot parse blank measurement", exception.message
+  end
+
+  test "#parse raises on a single incorrect string" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string("word")
+    end
+    assert_equal "Cannot parse measurement from 'word'", exception.message
+  end
+
+  test "#parse raises on a single incorrect number" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string("1234")
+    end
+    assert_equal "Cannot parse measurement from '1234'", exception.message
+  end
+
+  test "#parse raises on a multiple incorrect numbers" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string("12.34 9999")
+    end
+    assert_equal "Cannot parse measurement from '12.34 9999'", exception.message
+  end
+
+  test "#parse takes input with a space between" do
+    assert_equal [Rational(2, 1), "test"], Measured::Parser.parse_string("4/2 test")
+  end
+
+  test "#parse takes input without a space" do
+    assert_equal [Rational(7, 2), "test"], Measured::Parser.parse_string("3.5test")
+  end
+
+  test "#parse takes input with a number in the unit" do
+    assert_equal [Rational(1, 1), "test3test"], Measured::Parser.parse_string("1 test3test")
+  end
+
+  test "#parse raises on a number first unit digit" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string("1 1test")
+    end
+    assert_equal "Cannot parse measurement from '1 1test'", exception.message
+  end
+
+  test "#parse takes float with a space" do
+    assert_equal [Rational(5, 4), "test"], Measured::Parser.parse_string("1.25 test")
+  end
+
+  test "#parse takes float without a space" do
+    assert_equal [Rational(251, 5), "test"], Measured::Parser.parse_string("50.2test")
+  end
+
+  test "#parse truncates any space before and after" do
+    assert_equal [Rational(111111, 100), "test"], Measured::Parser.parse_string("   1111.11     test    ")
+  end
+
+  test "#parse raises with multiple periods in fractional numbers" do
+    exception = assert_raises(Measured::UnitError) do
+      Measured::Parser.parse_string("12.34.56 test")
+    end
+    assert_equal "Cannot parse measurement from '12.34.56 test'", exception.message
+  end
+
+  test "#parse takes multiple words for the unit" do
+    assert_equal [Rational(2345, 1), "a b cde"], Measured::Parser.parse_string(" 2345 a b cde  ")
+  end
+
+  test "#parse parses negative numbers" do
+    assert_equal [Rational(-13, 4), "test"], Measured::Parser.parse_string("-3.25 test")
+  end
+
+  test "#parse parses rational numbers" do
+    assert_equal [Rational(3, 2), "test"], Measured::Parser.parse_string("3/2test")
+  end
+end

--- a/test/support/fake_system.rb
+++ b/test/support/fake_system.rb
@@ -1,5 +1,5 @@
 Magic = Measured.build do
-  unit :magic_missile, aliases: [:magic_missiles]
+  unit :magic_missile, aliases: [:magic_missiles, "magic missile"]
   unit :fireball, value: "2/3 magic_missile", aliases: [:fire, :fireballs]
   unit :ice, value: "2 magic_missile"
   unit :arcane, value: "10 magic_missile"


### PR DESCRIPTION
I'm doing some work of loading weights from files, and I want to be able to have values in an input file:

```
weight: 10.5 kg
```

And then create a weight object out of it:

```
Measured::Weight.parse("10.5 kg")
```

It's way slower than taking in the number and the symbol, but we'd be parsing those strings from the file first anyway.