### PR TITLE
Add minitest reporters and update gems

### DIFF
--- a/measured.gemspec
+++ b/measured.gemspec
@@ -20,8 +20,9 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency "activesupport", ">= 4.2"
 
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_development_dependency "minitest", "~> 5.5.1"
-  spec.add_development_dependency "mocha", "~> 1.1.0"
+  spec.add_development_dependency "rake", "> 10.0"
+  spec.add_development_dependency "minitest", "> 5.5.1"
+  spec.add_development_dependency "minitest-reporters"
+  spec.add_development_dependency "mocha", "> 1.1.0"
   spec.add_development_dependency "pry"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,9 +1,12 @@
 require "measured"
+require "minitest/reporters"
 require "minitest/autorun"
 require "mocha/setup"
 require "pry"
 
 ActiveSupport.test_order = :random
+
+Minitest::Reporters.use! [Minitest::Reporters::ProgressReporter.new(color: true)]
 
 require "support/fake_system"
 


### PR DESCRIPTION
Add `minitest-reporters` to give us cleaner output, and unsick us from an old version. We're ok with new versions, and if it breaks we should fix it.

Related to https://github.com/Shopify/measured-rails/pull/36

![kevin_kevify____source_measured__zsh_](https://cloud.githubusercontent.com/assets/84159/23234379/eb42eba8-f91f-11e6-9e4a-9bf34d46f037.png)
