### PR TITLE
Make builtin unit systems opt-in by default

### DIFF
--- a/lib/measured.rb
+++ b/lib/measured.rb
@@ -1,4 +1,1 @@
 require "measured/base"
-
-require "measured/units/length"
-require "measured/units/weight"

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "measured/units/length"
 
 class Measured::LengthTest < ActiveSupport::TestCase
   test ".unit_names_with_aliases should be the expected list of valid units" do

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "measured/units/weight"
 
 class Measured::WeightTest < ActiveSupport::TestCase
   setup do


### PR DESCRIPTION
It's generally best for libraries to have most unnecessary things as opt-in, in case clients of the library want to do their own version of the things. For measured, this means we should probably have lengths and weights an opt-in feature, especially since they're not fully defined systems (e.g., weight is missing a ton of prefixes).

PR opened for discussion.