### PR TITLE
Turn grams into si_unit

### DIFF
--- a/lib/measured/units/weight.rb
+++ b/lib/measured/units/weight.rb
@@ -1,6 +1,6 @@
 Measured::Weight = Measured.build do
-  unit :g, aliases: [:gram, :grams]
-  unit :kg, value: "1000 g", aliases: [:kilogram, :kilograms]
+  si_unit :g, aliases: [:gram, :grams]
+
   unit :t, value: "1000 kg", aliases: [:metric_ton, :metric_tons]
   unit :slug, value: "14.593903 kg", aliases: [:slugs]
   unit :N, value: "0.10197162129779283 kg", aliases: [:newtons, :newton]

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -6,14 +6,48 @@ class Measured::WeightTest < ActiveSupport::TestCase
   end
 
   test ".unit_names_with_aliases should be the expected list of valid units" do
-    assert_equal(
-      %w(N W/T displacement_ton displacement_tons g gram grams imperial_ton imperial_tons kg kilogram kilograms lb lbs long_ton long_tons metric_ton metric_tons newton newtons ounce ounces oz pound pounds short_ton short_tons slug slugs t weight_ton weight_tons),
-      Measured::Weight.unit_names_with_aliases
+    expected_units = %w(
+      N
+      W/T
+      displacement_ton
+      displacement_tons
+      g
+      gram
+      grams
+      imperial_ton
+      imperial_tons
+      lb
+      lbs
+      long_ton
+      long_tons
+      metric_ton
+      metric_tons
+      newton
+      newtons
+      ounce
+      ounces
+      oz
+      pound
+      pounds
+      short_ton
+      short_tons
+      slug
+      slugs
+      t
+      weight_ton
+      weight_tons
     )
+    expected_units += Measured::UnitSystemBuilder::SI_PREFIXES.flat_map do |short, long, _|
+      ["#{short}g", "#{long}gram", "#{long}grams"]
+    end
+
+    assert_equal expected_units.sort, Measured::Weight.unit_names_with_aliases
   end
 
   test ".unit_names should be the list of base unit names" do
-    assert_equal %w(N g kg lb long_ton oz short_ton slug t), Measured::Weight.unit_names
+    expected_units = %w(N g lb long_ton oz short_ton slug t)
+    expected_units += Measured::UnitSystemBuilder::SI_PREFIXES.map { |short, _, _| "#{short}g" }
+    assert_equal expected_units.sort, Measured::Weight.unit_names
   end
 
   test "Measured::Weight() delegates automatically to .new" do


### PR DESCRIPTION
### Summary

Turn grams into a `si_unit` before releasing version 2.1.

### Obsrevations

Documentation and README are being updated in https://github.com/Shopify/measured/pull/92.

cc @mdking @MalazAlamir 