### PR TITLE
Fix 'ambiguous first argument' warnings in tests

### DIFF
--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -237,10 +237,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   end
 
   test "#<=> compares regardless of the unit" do
-    assert_equal -1, @magic <=> Magic.new(20, :fire)
+    assert_equal (-1), @magic <=> Magic.new(20, :fire)
     assert_equal 1, @magic <=> Magic.new(9, :magic_missile)
     assert_equal 0, @magic <=> Magic.new(Rational(30, 2), :fire)
-    assert_equal -1, @magic <=> Magic.new(11, :magic_missile)
+    assert_equal (-1), @magic <=> Magic.new(11, :magic_missile)
   end
 
   test "#<=> doesn't compare against zero" do

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -55,7 +55,7 @@ class Measured::UnitTest < ActiveSupport::TestCase
 
   test "#<=> compares non-Unit classes against name" do
     assert_equal 1, @unit <=> "Pap"
-    assert_equal -1, @unit <=> "Pop"
+    assert_equal (-1), @unit <=> "Pop"
   end
 
   test "#<=> is 0 for Unit instances that should be equivalent" do
@@ -65,12 +65,12 @@ class Measured::UnitTest < ActiveSupport::TestCase
   end
 
   test "#<=> is -1 for units with names that come after Pie lexicographically" do
-    assert_equal -1, @unit <=> Measured::Unit.new(:Pigs, value: "10 bacon")
-    assert_equal -1, @unit <=> Measured::Unit.new("Pig", aliases: %w(Pigs), value: "10 bacon")
+    assert_equal (-1), @unit <=> Measured::Unit.new(:Pigs, value: "10 bacon")
+    assert_equal (-1), @unit <=> Measured::Unit.new("Pig", aliases: %w(Pigs), value: "10 bacon")
   end
-  
+
   test "#<=> compares #conversion_amount when unit names the same" do
-    assert_equal -1, @unit <=> Measured::Unit.new(:Pie, value: [11, :pancake])
+    assert_equal (-1), @unit <=> Measured::Unit.new(:Pie, value: [11, :pancake])
     assert_equal 0, @unit <=> Measured::Unit.new(:Pie, value: [10, :foo])
     assert_equal 1, @unit <=> Measured::Unit.new(:Pie, value: [9, :pancake])
   end


### PR DESCRIPTION
Running the tests with warnings enabled (`-w` flag) reports that some expressions are ambiguous because of the lack of parenthesis and the usage of the unary operator `-`.

The output or `bundle exec rake test` / `dev test` before:

```
/Users/javierhonduco/.gem/ruby/2.3.1/gems/pry-0.11.1/lib/pry/commands/whereami.rb:196: warning: ambiguous first argument; put parentheses or a space even after `/' operator
/Users/javierhonduco/src/github.com/Shopify/measured/test/measurable_test.rb:240: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/javierhonduco/src/github.com/Shopify/measured/test/measurable_test.rb:243: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/javierhonduco/src/github.com/Shopify/measured/test/unit_test.rb:58: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/javierhonduco/src/github.com/Shopify/measured/test/unit_test.rb:68: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/javierhonduco/src/github.com/Shopify/measured/test/unit_test.rb:69: warning: ambiguous first argument; put parentheses or a space even after `-' operator
/Users/javierhonduco/src/github.com/Shopify/measured/test/unit_test.rb:73: warning: ambiguous first argument; put parentheses or a space even after `-' operator
```

This PR gets rid of the warnings caused library's tests 💨 ⚠️ 

We could also achieve this by wrapping other expressions instead of the number with lovely parenthesis, happy to change it if you think it's better 😄 
