### PR TITLE
Fix precision representation of floats

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -9,7 +9,7 @@ class Measured::Measurable < Numeric
     @unit = unit_from_unit_or_name!(unit)
     @value = case value
     when Float
-      BigDecimal(value, Float::DIG + 1)
+      BigDecimal(value, Float::DIG)
     when BigDecimal, Rational
       value
     when Integer

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,3 @@
 module Measured
-  VERSION = "2.1.0"
+  VERSION = "2.2.0"
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -216,6 +216,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "5 fireball", Magic.new(Rational(5, 1), :fire).to_s
   end
 
+  test "#to_s outputs the correct number of decimals" do
+    assert_equal "9.3 fireball", Magic.new(9.3, :fire).to_s
+  end
+
   test "#humanize outputs the number and the unit properly pluralized" do
     assert_equal "1 fireball", Magic.new("1", :fire).humanize
     assert_equal "10 fireballs", Magic.new(10, :fire).humanize


### PR DESCRIPTION
### Background
When performing string concatenations of `Measured::Weight.new(<number>, :lbs)` with a number that cannot be represented as a float, it is shown with too many decimals:

```
Measured::Weight.new(9.3, :lbs).to_s
=> "9.300000000000001 lb"
```
### Research
@benwah and I had a look of the history of the changes when we saw that [the rounding was being set to `Float::DIG + 1`](https://github.com/Shopify/measured/blob/76e7b7276b7cf435b3f7ac4402269b9a60dd9bf9/lib/measured/measurable.rb#L11-L12).

This behaviour was introduced in [this measured PR](https://github.com/Shopify/measured/pull/14), mimicking Ruby's `float#to_d` implementation behaviour.

However, with the current implementation of `Float::DIG + 1`, this is what we get:
```ruby
[2] pry(main)> BigDecimal(9.3, Float::DIG + 1).to_s
=> "9.300000000000001"
```
and with `Float::DIG`:
```ruby
[3] pry(main)> BigDecimal(9.3, Float::DIG + 1).to_s
=> "9.3"
```

while `float#to_d`:
```ruby
[4] pry(main)> 9.3.to_d.to_s
=> "9.3"
```

This was, indeed, changed in Ruby, as it can be seen in [this Ruby PR](https://github.com/ruby/ruby/pull/323). If you are curious, [it was introduced here](https://github.com/ruby/ruby/commit/079fb8d4c369cfc7d450d6e4d02b112596dcb5ee#commitcomment-3317139), this bug only lasted 5 days or so in trunk 😄 .

### Proposed implementation
Changing `BigDecimal(value, Float::DIG + 1)` to `value.to_d`, to use Ruby's implementation instead of calling with our defined precision 😃 .

This, however, leaves the code style a bit inconsistent, as the other expressions of the `when` use the constructor instead of a method call on themselves, but thought I would change that in another PR, if that sounds good :)

Given that this change is Ruby version dependant, I think we should maybe bump the version a bit more than I was expecting at first (minor or more?), this only happen in older Rubies, though.

What do you think? 😄 
