### PR TITLE
Add optional rounding to the string representation

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -28,8 +28,8 @@ class Measured::Measurable < Numeric
     self.class.new(new_value, new_unit)
   end
 
-  def to_s
-    @to_s ||= "#{value_string} #{unit.name}"
+  def to_s(round: nil)
+    @to_s ||= "#{value_string(round: round)} #{unit.name}"
   end
 
   def humanize
@@ -77,17 +77,19 @@ class Measured::Measurable < Numeric
     value.is_a?(Measured::Unit) ? value : self.class.unit_system.unit_for!(value)
   end
 
-  def value_string
+  def value_string(round: nil)
     @value_string ||= begin
-      str = case value
+      float = case value
       when Rational
-        value.denominator == 1 ? value.numerator.to_s : value.to_f.to_s
+        value.denominator == 1 ? value.numerator : value.to_f
       when BigDecimal
-        value.to_s("F")
+        value.to_f
       else
-        value.to_f.to_s
+        value.to_f
       end
-      str.gsub(/\.0*\Z/, "")
+
+      float = float.round(round) if round
+      float.to_s.gsub(/\.0*\Z/, "")
     end
   end
 end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -220,6 +220,12 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "9.3 fireball", Magic.new(9.3, :fire).to_s
   end
 
+  test "#to_s rounds when passed a rounding optional argument" do
+    assert_equal "0.333 fireball", Magic.new(1/3.0, :fire).to_s(round: 3)
+    assert_equal "0.333333 fireball", Magic.new(1/3.0, :fire).to_s(round: 6)
+    assert_equal "0.333333333333333 fireball", Magic.new(1/3.0, :fire).to_s(round: nil)
+  end
+
   test "#humanize outputs the number and the unit properly pluralized" do
     assert_equal "1 fireball", Magic.new("1", :fire).humanize
     assert_equal "10 fireballs", Magic.new(10, :fire).humanize


### PR DESCRIPTION
Hiii,

In #96 @alexgomez54 and I talked about a use case we had of stringifying a `Measurable` object in which we wanted to be able to round the number of displayed decimals.

This PR adds that functionality in the `#to_s` method, with an optional keyword argument `round`, which is `nil` by default. In case `nil` is received, it does the old logic. Otherwise, it rounds the float before building the string for us.

### Why this approach?
- The API is backwards compatible :tada:
- Thought that it might make sense to implement this in `measured` instead of `measured-rails` as this is an interesting feature no matter which web framework is being used 😄 
- It does not change the object itself as it would have some inconsistencies as @thegedge [mentioned](https://github.com/Shopify/measured/issues/96#issuecomment-341786502), it just build the string

That being said, I feel that maybe having this optional keyword argument in `#to_s`, such a common method, may feel weird. Was wondering if you think it would make more sense to have another method like`#to_s_with_rounding` or something on that. Happy to change it!! 😃 