### PR TITLE
Add formatter to Measurable closes #98

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,14 @@ Measured::Weight.unit_names_with_aliases
 > ["g", "gram", "grams", "kg", "kilogram", "kilograms", "lb", "lbs", "ounce", "ounces", "oz", "pound", "pounds"]
 ```
 
+String formatting:
+```ruby
+weight = Measured::Weight.new("3.14", "grams")
+weight.format("%.1<value>f %<unit>s")
+> "3.1 g"
+
+If no formatting string is passed, it uses `'%.2<value>f %<unit>s'`.
+```
 ## Units and conversions
 
 ### SI units support

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -28,6 +28,14 @@ class Measured::Measurable < Numeric
     self.class.new(new_value, new_unit)
   end
 
+  def format(format_string)
+    kwargs = {
+      value: self.value,
+      unit: self.unit,
+    }
+    format_string % kwargs
+  end
+
   def to_s
     @to_s ||= "#{value_string} #{unit.name}"
   end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -1,4 +1,6 @@
 class Measured::Measurable < Numeric
+  DEFAULT_FORMAT_STRING = '%.2<value>f %<unit>s'
+
   include Measured::Arithmetic
 
   attr_reader :unit, :value
@@ -28,12 +30,12 @@ class Measured::Measurable < Numeric
     self.class.new(new_value, new_unit)
   end
 
-  def format(format_string)
+  def format(format_string=nil)
     kwargs = {
       value: self.value,
       unit: self.unit,
     }
-    format_string % kwargs
+    (format_string || DEFAULT_FORMAT_STRING) % kwargs
   end
 
   def to_s

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -228,6 +228,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "9.342000 magic_missile", measured_object.format("%<value>f %<unit>s")
   end
 
+  test "#format with no formatting string uses the default one" do
+    assert_equal "9.34 magic_missile", Magic.new(9.342, :magic_missile).format
+  end
+
   test "#humanize outputs the number and the unit properly pluralized" do
     assert_equal "1 fireball", Magic.new("1", :fire).humanize
     assert_equal "10 fireballs", Magic.new(10, :fire).humanize

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -220,6 +220,14 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "9.3 fireball", Magic.new(9.3, :fire).to_s
   end
 
+  test "#format outputs a formatted string" do
+    measured_object = Magic.new(9.342, :magic_missile)
+    assert_equal "9.3", measured_object.format("%.1<value>f")
+    assert_equal "magic_missile", measured_object.format("%<unit>s")
+    assert_equal "9.34 magic_missile", measured_object.format("%.2<value>f %<unit>s")
+    assert_equal "9.342000 magic_missile", measured_object.format("%<value>f %<unit>s")
+  end
+
   test "#humanize outputs the number and the unit properly pluralized" do
     assert_equal "1 fireball", Magic.new("1", :fire).humanize
     assert_equal "10 fireballs", Magic.new(10, :fire).humanize


### PR DESCRIPTION
The PR adds `#format` to Measurable. Unsurprisingly, this adds a formatter to `measured` :tada:, as we discussed in #98.

Cheers!