### PR TITLE
Some low hanging performance improvements

### DIFF
--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -8,8 +8,9 @@ module Measured::ConversionTable
       to_table = {to_unit => BigDecimal("1")}
 
       table.each do |from_unit, from_table|
-        to_table[from_unit] = find_conversion(units, to: from_unit, from: to_unit)
-        from_table[to_unit] = find_conversion(units, to: to_unit, from: from_unit)
+        conversion = find_conversion(units, to: from_unit, from: to_unit)
+        to_table[from_unit] = conversion
+        from_table[to_unit] = 1 / conversion
       end
 
       table[to_unit] = to_table
@@ -31,9 +32,6 @@ module Measured::ConversionTable
   def find_direct_conversion(units, to:, from:)
     units.each do |unit|
       return unit.conversion_amount if unit.name == from && unit.conversion_unit == to
-    end
-
-    units.each do |unit|
       return unit.inverse_conversion_amount if unit.name == to && unit.conversion_unit == from
     end
 


### PR DESCRIPTION
Measured's performance when computing the conversions table could be improved. Although the hottest code path lies in the indirect conversions, while looking through the code, I spotted 2 low hanging performance gains.

1. We are computing the conversion between 2 units twice so we can have the reverse operation. We can replace the inverse operation by the mathematical inverse, the power of `-1` (which is equivalent to `1/conversion`. This makes running this code approximately twice as fast.

2. Some other minor gain comes from the `find_direct_conversion`. We check if there's any conversion from unit A to each of those possible units by checking each of those's `conversion_amount`. We then do the same but checking for the `inverse_conversion_amount`. Even though the computational complexity stays the same, the constant increases, and it matters in this case.

Some Not Very Scientific(TM) benchmarks (running the test suite 3 times each, avg'ed):
- No changes: `4.10s`
- Applying 2: `3.15s`
- Applying 1: `2.10s`
- This whole patch: `1.15s` 

This is somehow synthetic, but nevertheless an interesting performance gain. 

With this snippet of code:
```ruby
require 'benchmark/ips'
require 'measured'

Benchmark.ips do |x|
  x.report('simple-measure') { Measured::Volume.parse("123 fl_oz").convert_to("ml") }
  x.compare!
end
```

And the following patch to add `benchmark-ips` and to remove the conversion table caching, so we have a more real-life scenario, applied on top of this branch:
```patch
diff --git a/lib/measured/unit_system.rb b/lib/measured/unit_system.rb
index bddca08..9fb2352 100644
--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -43,7 +43,7 @@ class Measured::UnitSystem
   protected

   def conversion_table
-    @conversion_table ||= Measured::ConversionTable.build(@units)
+    Measured::ConversionTable.build(@units)
   end

   def unit_name_to_unit
diff --git a/measured.gemspec b/measured.gemspec
index 192aa9a..ddfdd36 100644
--- a/measured.gemspec
+++ b/measured.gemspec
@@ -25,4 +25,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-reporters"
   spec.add_development_dependency "mocha", "> 1.1.0"
   spec.add_development_dependency "pry"
+  spec.add_development_dependency "benchmark-ips"
 end
```

Yielded `1.737  (± 0.0%) i/s ` for this PR and `0.453  (± 0.0%) i/s` for the current implementation

Let me know what you think,