### PR TITLE
Guard against nil in Unit#conversion_amount

### DIFF
--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -54,7 +54,7 @@ class Measured::Unit
   end
 
   def inverse_conversion_amount
-    @inverse_conversion_amount ||= 1 / conversion_amount
+    @inverse_conversion_amount ||= 1 / conversion_amount if conversion_amount
   end
 
   private

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -78,4 +78,8 @@ class Measured::UnitTest < ActiveSupport::TestCase
   test "#inverse_conversion_amount returns 1/amount" do
     assert_equal Rational(1, 10), @unit.inverse_conversion_amount
   end
+
+  test "#inverse_conversion_amount handles nil for base unit" do
+    assert_nil Measured::Unit.new(:pie).inverse_conversion_amount
+  end
 end


### PR DESCRIPTION
## Problem

In cases of the base unit the `conversion_amount` can validly be `nil`.

## Solution

Just pass through the `nil`, and test to prevent regressions.