### PR TITLE
Chanage Measured::ConversionTable from a module to a class

### DIFF
--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -43,19 +43,21 @@ class Measured::ConversionTable
   end
 
   def find_tree_traversal_conversion(to:, from:)
-    traverse(from: from, to: to, unit_names: units.map(&:name), amount: 1)
+    traverse(from: from, to: to, units_remaining: units.map(&:name), amount: 1)
   end
 
-  def traverse(from:, to:, unit_names:, amount:)
-    unit_names = unit_names - [from]
+  def traverse(from:, to:, units_remaining:, amount:)
+    units_remaining = units_remaining - [from]
 
-    unit_names.each do |name|
-      if conversion = find_direct_conversion(from: from, to: name)
+    units_remaining.each do |name|
+      conversion = find_direct_conversion(from: from, to: name)
+
+      if conversion
         new_amount = amount * conversion
         if name == to
           return new_amount
         else
-          result = traverse(from: name, to: to, unit_names: unit_names, amount: new_amount)
+          result = traverse(from: name, to: to, units_remaining: units_remaining, amount: new_amount)
           return result if result
         end
       end

--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -1,7 +1,11 @@
-module Measured::ConversionTable
-  extend self
+class Measured::ConversionTable
+  attr_reader :units
 
-  def build(units)
+  def initialize(units)
+    @units = units
+  end
+
+  def to_h
     table = {}
 
     units.map{|u| u.name}.each do |to_unit|

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -43,7 +43,7 @@ class Measured::UnitSystem
   protected
 
   def conversion_table
-    @conversion_table ||= Measured::ConversionTable.build(@units)
+    @conversion_table ||= Measured::ConversionTable.new(@units).to_h
   end
 
   def unit_name_to_unit

--- a/test/conversion_table_test.rb
+++ b/test/conversion_table_test.rb
@@ -1,19 +1,25 @@
 require "test_helper"
 
 class Measured::ConversionTableTest < ActiveSupport::TestCase
-  test ".build should return a hash for the simple case" do
+  test "#initialize creates a new object with the units" do
+    units = [Measured::Unit.new(:test)]
+
+    assert_equal units, Measured::ConversionTable.new(units).units
+  end
+
+  test "#to_h should return a hash for the simple case" do
     expected = {
       "test" => {"test" => BigDecimal("1")}
     }
 
-    assert_equal expected, Measured::ConversionTable.build([Measured::Unit.new(:test)])
+    assert_equal expected, Measured::ConversionTable.new([Measured::Unit.new(:test)]).to_h
   end
 
-  test ".build returns expected nested hashes with BigDecimal conversion factors in a tiny data set" do
-    conversion_table = Measured::ConversionTable.build([
+  test "#to_h returns expected nested hashes with BigDecimal conversion factors in a tiny data set" do
+    conversion_table = Measured::ConversionTable.new([
       Measured::Unit.new(:m),
       Measured::Unit.new(:cm, value: "0.01 m"),
-    ])
+    ]).to_h
 
     expected = {
       "m" => {
@@ -29,12 +35,12 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
     assert_equal expected, conversion_table
   end
 
-  test ".build returns expected nested hashes with BigDecimal conversion factors" do
-    conversion_table = Measured::ConversionTable.build([
+  test "#to_h returns expected nested hashes with BigDecimal conversion factors" do
+    conversion_table = Measured::ConversionTable.new([
       Measured::Unit.new(:m),
       Measured::Unit.new(:cm, value: "0.01 m"),
       Measured::Unit.new(:mm, value: "0.001 m"),
-    ])
+    ]).to_h
 
     expected = {
       "m" => {
@@ -57,13 +63,13 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
     assert_equal expected, conversion_table
   end
 
-  test ".build returns expected nested hashes with BigDecimal conversion factors in an indrect path" do
-    conversion_table = Measured::ConversionTable.build([
+  test "#to_h returns expected nested hashes with BigDecimal conversion factors in an indrect path" do
+    conversion_table = Measured::ConversionTable.new([
       Measured::Unit.new(:mm),
       Measured::Unit.new(:cm, value: "10 mm"),
       Measured::Unit.new(:dm, value: "10 cm"),
       Measured::Unit.new(:m, value: "10 dm"),
-    ])
+    ]).to_h
 
     expected = {
       "m" => {
@@ -94,5 +100,4 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
 
     assert_equal expected, conversion_table
   end
-
 end


### PR DESCRIPTION
## Problem

The `Measured::ConversionTable` is built as a module where each method passes in the state. 

This is pretty unnecessary. It makes the signatures messy and it's way harder to refactor as I'm trying to do for #103.

## Solution

Convert it from a module to a class. Instantiate it and call `#to_h`. No functional change, just an internal API change.