### PR TITLE
Allow only certain test files to be run via rake test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,9 +8,12 @@ task default: :test
 
 desc 'Run the test stuite'
 Rake::TestTask.new do |t|
+  files = ARGV[1..-1]
+  files = "test/**/*_test.rb" if !files || files.length == 0
+
   t.libs << "test"
   t.libs << "lib/**/*"
-  t.test_files = FileList['test/**/*_test.rb']
+  t.test_files = FileList[files]
   t.verbose = true
 end
 


### PR DESCRIPTION
## Problem

Internally at Shopify we use `dev` to run our tests. But any contributors to this gem will use `rake test` to run the tests. And this doesn't easily allow you to run just specific test files.

## Solution

Add a check in the `Rakefile` allowing you to pass in a test file or many test files into `rake test test/file.rb` and run just that test.