### PR TITLE
Make the 1 to 1 factor of the conversion table be a Rational rather than BigDecimal

### DIFF
--- a/lib/measured/conversion_table.rb
+++ b/lib/measured/conversion_table.rb
@@ -9,7 +9,7 @@ class Measured::ConversionTable
     table = {}
 
     units.map{|u| u.name}.each do |to_unit|
-      to_table = {to_unit => BigDecimal("1")}
+      to_table = {to_unit => Rational(1, 1)}
 
       table.each do |from_unit, from_table|
         conversion = find_conversion(to: from_unit, from: to_unit)

--- a/test/conversion_table_test.rb
+++ b/test/conversion_table_test.rb
@@ -8,11 +8,14 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
   end
 
   test "#to_h should return a hash for the simple case" do
+    conversion_table = Measured::ConversionTable.new([Measured::Unit.new(:test)]).to_h
+
     expected = {
-      "test" => {"test" => BigDecimal("1")}
+      "test" => {"test" => Rational(1, 1)}
     }
 
-    assert_equal expected, Measured::ConversionTable.new([Measured::Unit.new(:test)]).to_h
+    assert_equal expected, conversion_table
+    assert_instance_of Rational, conversion_table.values.first.values.first
   end
 
   test "#to_h returns expected nested hashes with BigDecimal conversion factors in a tiny data set" do
@@ -23,19 +26,23 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
 
     expected = {
       "m" => {
-        "m" => BigDecimal("1"),
-        "cm" => BigDecimal("100"),
+        "m" => Rational(1, 1),
+        "cm" => Rational(100, 1),
       },
       "cm" => {
-        "m" => BigDecimal("0.01"),
-        "cm" => BigDecimal("1"),
+        "m" => Rational(1, 100),
+        "cm" => Rational(1, 1),
       }
     }
 
     assert_equal expected, conversion_table
+
+    conversion_table.values.map(&:values).flatten.each do |value|
+      assert_instance_of Rational, value
+    end
   end
 
-  test "#to_h returns expected nested hashes with BigDecimal conversion factors" do
+  test "#to_h returns expected nested hashes factors" do
     conversion_table = Measured::ConversionTable.new([
       Measured::Unit.new(:m),
       Measured::Unit.new(:cm, value: "0.01 m"),
@@ -44,26 +51,30 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
 
     expected = {
       "m" => {
-        "m" => BigDecimal("1"),
-        "cm" => BigDecimal("100"),
-        "mm" => BigDecimal("1000"),
+        "m" => Rational(1, 1),
+        "cm" => Rational(100, 1),
+        "mm" => Rational(1000, 1),
       },
       "cm" => {
-        "m" => BigDecimal("0.01"),
-        "cm" => BigDecimal("1"),
-        "mm" => BigDecimal("10"),
+        "m" => Rational(1, 100),
+        "cm" => Rational(1, 1),
+        "mm" => Rational(10, 1),
       },
       "mm" => {
-        "m" => BigDecimal("0.001"),
-        "cm" => BigDecimal("0.1"),
-        "mm" => BigDecimal("1"),
+        "m" => Rational(1, 1000),
+        "cm" => Rational(1, 10),
+        "mm" => Rational(1, 1),
       }
     }
 
     assert_equal expected, conversion_table
+
+    conversion_table.values.map(&:values).flatten.each do |value|
+      assert_instance_of Rational, value
+    end
   end
 
-  test "#to_h returns expected nested hashes with BigDecimal conversion factors in an indrect path" do
+  test "#to_h returns expected nested hashes in an indrect path" do
     conversion_table = Measured::ConversionTable.new([
       Measured::Unit.new(:mm),
       Measured::Unit.new(:cm, value: "10 mm"),
@@ -73,31 +84,35 @@ class Measured::ConversionTableTest < ActiveSupport::TestCase
 
     expected = {
       "m" => {
-        "m" => BigDecimal("1"),
-        "dm" => BigDecimal("10"),
-        "cm" => BigDecimal("100"),
-        "mm" => BigDecimal("1000"),
+        "m" => Rational(1, 1),
+        "dm" => Rational(10, 1),
+        "cm" => Rational(100, 1),
+        "mm" => Rational(1000, 1),
       },
       "cm" => {
-        "m" => BigDecimal("0.01"),
-        "dm" => BigDecimal("0.1"),
-        "cm" => BigDecimal("1"),
-        "mm" => BigDecimal("10"),
+        "m" => Rational(1, 100),
+        "dm" => Rational(1, 10),
+        "cm" => Rational(1, 1),
+        "mm" => Rational(10, 1),
       },
       "dm" => {
-        "m" => BigDecimal("0.1"),
-        "cm" => BigDecimal("10"),
-        "dm" => BigDecimal("1"),
-        "mm" => BigDecimal("100"),
+        "m" => Rational(1, 10),
+        "cm" => Rational(10, 1),
+        "dm" => Rational(1, 1),
+        "mm" => Rational(100, 1),
       },
       "mm" => {
-        "m" => BigDecimal("0.001"),
-        "dm" => BigDecimal("0.01"),
-        "cm" => BigDecimal("0.1"),
-        "mm" => BigDecimal("1"),
+        "m" => Rational(1, 1000),
+        "dm" => Rational(1, 100),
+        "cm" => Rational(1, 10),
+        "mm" => Rational(1, 1),
       }
     }
 
     assert_equal expected, conversion_table
+
+    conversion_table.values.map(&:values).flatten.each do |value|
+      assert_instance_of Rational, value
+    end
   end
 end


### PR DESCRIPTION
## Problem

Every factor in a conversion table is a `Rational` except the base one.

```
[1] pry(Measured::ConversionTable)> table
=> {"m"=>{"m"=>#<BigDecimal:561f2c7baf88,'0.1E1',9(18)>, "cm"=>(100/1), "mm"=>(1000/1)},
 "cm"=>{"cm"=>#<BigDecimal:561f2c7babf0,'0.1E1',9(18)>, "m"=>(1/100), "mm"=>(10/1)},
 "mm"=>{"mm"=>#<BigDecimal:561f2c7ba858,'0.1E1',9(18)>, "m"=>(1/1000), "cm"=>(1/10)}}
```

They all get coerced, but it doesn't make sense to keep it as a `BigDecimal` as the rest have been converted.

## Solution

Change it to `Rational(1, 1)`.

Rewrote and improved a bunch of tests. These tests were actually coercing on comparison so they weren't type checking. Added the type checks too now.