### PR TITLE
Make dev test use rake test

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -14,5 +14,5 @@ commands:
       if [[ $# -eq 0 ]]; then
         bundle exec rake test
       else
-        bundle exec ruby -Itest "$@"
+        bundle exec rake test "$@"
       fi


### PR DESCRIPTION
The current implementation doesn't allow to run multiple tests from `dev`. This PR uses #108 to do so.