### PR TITLE
Do not require pry in CI

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,7 +2,7 @@ require "measured"
 require "minitest/reporters"
 require "minitest/autorun"
 require "mocha/setup"
-require "pry"
+require "pry" unless ENV["CI"]
 
 ActiveSupport.test_order = :random
 


### PR DESCRIPTION
This prevents `pry` from being loaded in the CI environment. This would have failed tests in #102 and will prevent this kind of thing from happening again. Great suggestion from @sshaw in #104.

Tested by referencing `Pry` in a test and it failed in CI:
![job__623_1_-_shopify_measured_-_travis_ci](https://user-images.githubusercontent.com/84159/35294010-7aa31798-0043-11e8-8961-3ff1d67217f0.png)
