### PR TITLE
Fix Add new units README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ Measured::Thing = Measured.build do
 
   unit :another_unit,        # Add a second unit to the system
     aliases: [:au],          # All units allow aliases, as long as they are unique
-    value: ["1.5 bu"]        # The conversion rate to another unit
+    value: "1.5 bu"        # The conversion rate to another unit
 end
 ```
 


### PR DESCRIPTION
* In the example the conversion rate is set using:

```
value: ["1.5 bu"]
```

To set a conversion rate you must pass either a [string or a
two-element array](https://github.com/Shopify/measured/blob/master/lib/measured/unit.rb#L71).

This updates the docs to use a string

```
value: "1.5 bu"
```

note how all the other units are using the string version https://github.com/Shopify/measured/tree/master/lib/measured/units