### PR TITLE
Raise ruby requirement to 2.3 and rails to 5.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,19 +2,13 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.1.8
-  - 2.2.4
-  - 2.3.1
-  - 2.4.0
-  - 2.5.0
+  - 2.3.8
+  - 2.4.5
+  - 2.5.3
+  - 2.6.0
 gemfile:
   - Gemfile
-  - gemfiles/activesupport-4.2.gemfile
+  - gemfiles/activesupport-5.0.gemfile
+  - gemfiles/activesupport-5.1.gemfile
 before_script:
   - gem update --system
-matrix:
-  exclude:
-    - gemfile: Gemfile
-      rvm: 2.1.8
-    - gemfile: gemfiles/activesupport-4.2.gemfile
-      rvm: 2.4.0

--- a/gemfiles/activesupport-5.0.gemfile
+++ b/gemfiles/activesupport-5.0.gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec path: '..'
 
-gem 'activesupport', '~> 4.2'
+gem 'activesupport', '~> 5.0'

--- a/gemfiles/activesupport-5.1.gemfile
+++ b/gemfiles/activesupport-5.1.gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 5.1'

--- a/measured.gemspec
+++ b/measured.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 4.2"
+  spec.add_runtime_dependency "activesupport", ">= 5.0"
 
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "minitest", "> 5.5.1"


### PR DESCRIPTION
This modernizes the requirements for ruby and rails for this gem. ruby >= 2.3 and rails >= 5.0.

Also adds ruby 2.6.

It matches the maintenance policies of both:
https://guides.rubyonrails.org/maintenance_policy.html
https://www.ruby-lang.org/en/news/2017/04/01/support-of-ruby-2-1-has-ended/

Will follow up with a version change.

Matched with https://github.com/Shopify/measured-rails/pull/53