### PR TITLE
Fix BigDecimal deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ gem 'measured', require: 'measured/base'
 
 ### Shortcut syntax
 
-There is a shortcut initialization syntax for modules inside the `Measured` namespace, similar to `BigDecimal(123)` vs `BigDecimal.new(123)`:
+There is a shortcut initialization syntax for creating instances of measurement classes that can avoid the `.new`:
 
 ```ruby
 Measured::Weight(1, :g)

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -261,7 +261,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test "#<=> doesn't compare against zero" do
     assert_nil @magic <=> 0
-    assert_nil @magic <=> BigDecimal.new(0)
+    assert_nil @magic <=> BigDecimal(0)
     assert_nil @magic <=> 0.00
   end
 
@@ -279,7 +279,7 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
   test "#== doesn't compare against zero" do
     arcane_zero = Magic.new(0, :arcane)
     refute_equal arcane_zero, 0
-    refute_equal arcane_zero, BigDecimal.new(0)
+    refute_equal arcane_zero, BigDecimal(0)
     refute_equal arcane_zero, 0.0
   end
 
@@ -295,10 +295,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
 
   test "#> and #< should not compare against zero" do
     assert_raises(ArgumentError) { @magic > 0 }
-    assert_raises(ArgumentError) { @magic > BigDecimal.new(0) }
+    assert_raises(ArgumentError) { @magic > BigDecimal(0) }
     assert_raises(ArgumentError) { @magic > 0.00 }
     assert_raises(ArgumentError) { @magic < 0 }
-    assert_raises(ArgumentError) { @magic < BigDecimal.new(0) }
+    assert_raises(ArgumentError) { @magic < BigDecimal(0) }
     assert_raises(ArgumentError) { @magic < 0.00 }
   end
 end


### PR DESCRIPTION
Fixes:
```
measurable_test.rb:301: warning: BigDecimal.new is deprecated; use BigDecimal() method instead.
```