### PR TITLE
Add # frozen_string_literal: true

### DIFF
--- a/lib/measured.rb
+++ b/lib/measured.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "measured/base"
 
 require "measured/units/length"

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Arithmetic
   def +(other)
     arithmetic_operation(other, :+)

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "forwardable"
 require "measured/version"
 require "active_support/all"

--- a/lib/measured/cache/json.rb
+++ b/lib/measured/cache/json.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Cache
   class Json
     attr_reader :filename, :path

--- a/lib/measured/cache/json_writer.rb
+++ b/lib/measured/cache/json_writer.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Cache::JsonWriter
   def write(table)
     File.open(@path, "w") do |f|

--- a/lib/measured/cache/null.rb
+++ b/lib/measured/cache/null.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Cache
   class Null
     def exist?

--- a/lib/measured/conversion_table_builder.rb
+++ b/lib/measured/conversion_table_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Measured::ConversionTableBuilder
   attr_reader :units
 
@@ -87,5 +88,4 @@ class Measured::ConversionTableBuilder
 
     nil
   end
-
 end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -1,5 +1,6 @@
+# frozen_string_literal: true
 class Measured::Measurable < Numeric
-  DEFAULT_FORMAT_STRING = '%.2<value>f %<unit>s'
+  DEFAULT_FORMAT_STRING = "%.2<value>f %<unit>s"
 
   include Measured::Arithmetic
 

--- a/lib/measured/parser.rb
+++ b/lib/measured/parser.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured::Parser
   extend self
 

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Measured::Unit
   include Comparable
 

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Measured::UnitSystem
   attr_reader :units
 

--- a/lib/measured/unit_system_builder.rb
+++ b/lib/measured/unit_system_builder.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class Measured::UnitSystemBuilder
   def initialize
     @units = []
@@ -45,8 +46,8 @@ class Measured::UnitSystemBuilder
     ["P", "peta", 15],
     ["E", "exa", 18],
     ["Z", "zetta", 21],
-    ["Y", "yotta", 24]
-  ]
+    ["Y", "yotta", 24],
+  ].map(&:freeze).freeze
 
   def build_si_units(name, aliases: [], value: nil)
     si_units = [build_unit(name, aliases: aliases, value: value)]

--- a/lib/measured/units/length.rb
+++ b/lib/measured/units/length.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Measured::Length = Measured.build do
   si_unit :m, aliases: [:meter, :metre, :meters, :metres]
 

--- a/lib/measured/units/volume.rb
+++ b/lib/measured/units/volume.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Measured::Volume = Measured.build do
   si_unit :l, aliases: [:liter, :litre, :liters, :litres]
 

--- a/lib/measured/units/weight.rb
+++ b/lib/measured/units/weight.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Measured::Weight = Measured.build do
   si_unit :g, aliases: [:gram, :grams]
 

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured
   VERSION = "2.5.0"
 end

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::ArithmeticTest < ActiveSupport::TestCase

--- a/test/cache/json_test.rb
+++ b/test/cache/json_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::Cache::JsonTest < ActiveSupport::TestCase

--- a/test/cache/json_writer_test.rb
+++ b/test/cache/json_writer_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::Cache::JsonWriterTest < ActiveSupport::TestCase

--- a/test/cache/null_test.rb
+++ b/test/cache/null_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::Cache::NullTest < ActiveSupport::TestCase

--- a/test/cache_consistency_test.rb
+++ b/test/cache_consistency_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 # In general we do not want to expose the inner workings of the caching and unit systems as part of the API.

--- a/test/conversion_table_builder_test.rb
+++ b/test/conversion_table_builder_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::ConversionTableBuilderTest < ActiveSupport::TestCase

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -1,7 +1,7 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::MeasurableTest < ActiveSupport::TestCase
-
   setup do
     @arcane = Magic.unit_system.unit_for!(:arcane)
     @fireball = Magic.unit_system.unit_for!(:fireball)

--- a/test/parser_test.rb
+++ b/test/parser_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::ParserTest < ActiveSupport::TestCase

--- a/test/support/always_true_cache.rb
+++ b/test/support/always_true_cache.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 class AlwaysTrueCache
   def exist?
     true

--- a/test/support/fake_system.rb
+++ b/test/support/fake_system.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 Magic = Measured.build do
   unit :magic_missile, aliases: [:magic_missiles, "magic missile"]
   unit :fireball, value: "2/3 magic_missile", aliases: [:fire, :fireballs]

--- a/test/support/subclasses.rb
+++ b/test/support/subclasses.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Extract the subclasses that exist early on because other classes will get added by tests
 #   later on in execution and in an unpredictable order.
 class ActiveSupport::TestCase

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "pry" unless ENV["CI"]
 require "measured"
 require "minitest/reporters"

--- a/test/unit_error_test.rb
+++ b/test/unit_error_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::UnitErrorTest < ActiveSupport::TestCase

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase

--- a/test/unit_system_test.rb
+++ b/test/unit_system_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::UnitSystemTest < ActiveSupport::TestCase

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::UnitTest < ActiveSupport::TestCase

--- a/test/units/length_test.rb
+++ b/test/units/length_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::LengthTest < ActiveSupport::TestCase
@@ -142,7 +143,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from km to mi" do
-    assert_conversion Measured::Length, "2000 km", "0.1242742384475E4 mi" 
+    assert_conversion Measured::Length, "2000 km", "0.1242742384475E4 mi"
   end
 
   test ".convert_to from km to mm" do
@@ -150,7 +151,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from km to yd" do
-    assert_conversion Measured::Length, "2000 km", "0.218722659667542E7 yd" 
+    assert_conversion Measured::Length, "2000 km", "0.218722659667542E7 yd"
   end
 
   test ".convert_to from m to cm" do
@@ -206,7 +207,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from mi to mi" do
-    assert_exact_conversion Measured::Length, "2000 mi", "2000 mi" 
+    assert_exact_conversion Measured::Length, "2000 mi", "2000 mi"
   end
 
   test ".convert_to from mi to mm" do
@@ -214,7 +215,7 @@ class Measured::LengthTest < ActiveSupport::TestCase
   end
 
   test ".convert_to from mi to yd" do
-    assert_exact_conversion Measured::Length, "2000 mi", "3520000 yd" 
+    assert_exact_conversion Measured::Length, "2000 mi", "3520000 yd"
   end
 
   test ".convert_to from mm to cm" do

--- a/test/units/volume_test.rb
+++ b/test/units/volume_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::VolumeTest < ActiveSupport::TestCase
@@ -68,7 +69,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
   test ".unit_names should be the list of base unit names" do
     expected_units = %w(l m3 ft3 in3 gal us_gal qt us_qt pt us_pt oz us_oz)
     expected_units += Measured::UnitSystemBuilder::SI_PREFIXES.map { |short, _, _| "#{short}l" }
-    assert_equal expected_units.sort, Measured::Volume.unit_names 
+    assert_equal expected_units.sort, Measured::Volume.unit_names
   end
 
   test ".name" do
@@ -95,7 +96,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
   test ".convert_to from gal to gal" do
     assert_conversion Measured::Volume, "2000 gal", "2000 gal"
   end
-  
+
   test ".convert_to from us_gal to us_gal" do
     assert_conversion Measured::Volume, "2000 us_gal", "2000 us_gal"
   end
@@ -123,7 +124,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
   test ".convert_to from us_oz to us_oz" do
     assert_conversion Measured::Volume, "2000 us_oz", "2000 us_oz"
   end
-  
+
   test ".convert_to from ml to m3" do
     assert_conversion Measured::Volume, "2000 ml", "0.002 m3"
   end
@@ -303,7 +304,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
   test ".convert_to from gal to us_oz" do
     assert_conversion Measured::Volume, "2 gal", "307.4431809292 us_oz"
   end
-  
+
   test ".convert_to from us_gal to qt" do
     assert_conversion Measured::Volume, "2 us_gal", "6.661393477 qt"
   end

--- a/test/units/weight_test.rb
+++ b/test/units/weight_test.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 require "test_helper"
 
 class Measured::WeightTest < ActiveSupport::TestCase


### PR DESCRIPTION
Basically just adds the `# frozen_string_literal: true` comment everywhere, along with a few `.freeze` and string cleanups.

Related to https://github.com/Shopify/measured-rails/pull/59