### PR TITLE
Reconsider most memoizations

### DIFF
--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -24,10 +24,9 @@ module Measured
 
     def method_missing(method, *args)
       class_name = "Measured::#{ method }"
+      klass = class_name.safe_constantize
 
-      if Measurable.subclasses.map(&:to_s).include?(class_name)
-        klass = class_name.constantize
-
+      if klass && klass < Measurable
         Measured.define_singleton_method(method) do |value, unit|
           klass.new(value, unit)
         end

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -20,6 +20,18 @@ class Measured::Measurable < Numeric
     else
       BigDecimal(value)
     end
+
+    @value_string = begin
+      str = case value
+      when Rational
+        value.denominator == 1 ? value.numerator.to_s : value.to_f.to_s
+      when BigDecimal
+        value.to_s("F")
+      else
+        value.to_f.to_s
+      end
+      str.gsub(/\.0*\Z/, "")
+    end.freeze
   end
 
   def convert_to(new_unit)
@@ -40,18 +52,16 @@ class Measured::Measurable < Numeric
   end
 
   def to_s
-    @to_s ||= "#{value_string} #{unit.name}"
+    "#{@value_string} #{unit.name}"
   end
 
   def humanize
-    @humanize ||= begin
-      unit_string = value == 1 ? unit.name : ActiveSupport::Inflector.pluralize(unit.name)
-      "#{value_string} #{unit_string}"
-    end
+    unit_string = value == 1 ? unit.name : ActiveSupport::Inflector.pluralize(unit.name)
+    "#{@value_string} #{unit_string}"
   end
 
   def inspect
-    @inspect ||= "#<#{self.class}: #{value_string} #{unit.inspect}>"
+    "#<#{self.class}: #{@value_string} #{unit.inspect}>"
   end
 
   def <=>(other)
@@ -86,19 +96,5 @@ class Measured::Measurable < Numeric
 
   def unit_from_unit_or_name!(value)
     value.is_a?(Measured::Unit) ? value : self.class.unit_system.unit_for!(value)
-  end
-
-  def value_string
-    @value_string ||= begin
-      str = case value
-      when Rational
-        value.denominator == 1 ? value.numerator.to_s : value.to_f.to_s
-      when BigDecimal
-        value.to_s("F")
-      else
-        value.to_f.to_s
-      end
-      str.gsub(/\.0*\Z/, "")
-    end
   end
 end


### PR DESCRIPTION
### Context

I'm investigating memory leaks, or more exactly "durable post boot memory growth". Meaning I'm looking for objects that are allocated during a request cycle, but are held onto after the request was completed.

In this context, the profile data showed memory growth coming from `Measured::UnitSystem` and `Measured::Unit`, after a quick look it maps to the multiple uses of the memoization pattern (`@foo ||=`).

e.g:
```json
{"address":"0x56110c869930", "type":"HASH", "class":"0x5610e4f29338", "size":28, "references":["0x5610e84f9378",
```

```
harb> rootpath 0x56110c869930
root path to 0x56110c869930:
                      ROOT (machine_context)
                      0x5610e6098948 (CLASS: Rack::BodyProxy)
                      0x5610e4f41730 (CLASS: Object)
                      0x5610e85484c8 (MODULE: Measured)
                      0x5610e84e8640 (CLASS: Measured::Weight)
                      0x5610e84e84d8 (OBJECT: Measured::UnitSystem)
                      0x56110c869930 (HASH: size 28)
```

That pattern in itself isn't bad, but when it's used inside "constant" data structures, it's usually preferable to either precompute the values in the initializer or to simply not cache them based on their computation cost, memory usage, and likeliness to be accessed.

I tried to apply this logic here, in most case I chose to precompute as to not impact runtime performance, but in a few case like `inspect` I assumed they were very unlikely to be called in production so I chose to simply remove the caching.

I don't have a perfect context onto the gem, so feel free challenge these decisions.

