### PR TITLE
Allow unit values to be defined as aliases and not only the base unit

### DIFF
--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -14,12 +14,12 @@ class Measured::Unit
     @unit_system = unit_system
   end
 
-  def with_unit_system(unit_system)
+  def with(name: nil, unit_system: nil, aliases: nil, value: nil)
     self.class.new(
-      name,
-      aliases: aliases,
-      value: @conversion_string,
-      unit_system: unit_system
+      name || self.name,
+      aliases: aliases || self.aliases,
+      value: value || @conversion_string,
+      unit_system: unit_system || self.unit_system
     )
   end
 

--- a/lib/measured/unit_system.rb
+++ b/lib/measured/unit_system.rb
@@ -3,7 +3,13 @@ class Measured::UnitSystem
   attr_reader :units, :unit_names, :unit_names_with_aliases
 
   def initialize(units, cache: nil)
-    @units = units.map { |unit| unit.with_unit_system(self) }
+    @units = units.map { |unit| unit.with(unit_system: self) }
+    @units = @units.map do |unit|
+      next unit unless unit.conversion_unit
+      conversion_unit = @units.find { |u| u.names.include?(unit.conversion_unit) }
+      next unit unless conversion_unit
+      unit.with(value: [unit.conversion_amount, conversion_unit.name])
+    end
     @unit_names = @units.map(&:name).sort.freeze
     @unit_names_with_aliases = @units.flat_map(&:names).sort.freeze
     @unit_name_to_unit = @units.each_with_object({}) do |unit, hash|

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -39,6 +39,16 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
     assert_equal 'BOLD', measurable.unit_system.unit_for!(:BOLD).name
   end
 
+  test "#unit traverses aliases" do
+    measurable = Measured.build do
+      unit :piece, aliases: [:pieces]
+      unit :dozen, aliases: [:dz], value: "12 pieces"
+    end
+
+    assert_equal 12, measurable.unit_system.units.last.conversion_amount
+    assert_equal "piece", measurable.unit_system.units.last.conversion_unit
+  end
+
   test "#si_unit adds 21 new units" do
     measurable = Measured.build do
       unit :ft


### PR DESCRIPTION
As described in #127 @trcarden, defining the value of a unit using an alias raises.

This happens because we don't have the `UnitSystem` defined yet that can look up the aliases. It's a chicken egg problem.

So we do the search manually in this case, rather than error. It's not a huge amount of effort, with a little duplication.

I've refactored the `with(` method to maintain immutability of `Unit`.