### PR TITLE
Fix travis build and only support current ruby versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,8 +11,6 @@ gemfile:
   - gemfiles/activesupport-5.0.gemfile
   - gemfiles/activesupport-5.1.gemfile
   - gemfiles/activesupport-6.0.gemfile
-before_script:
-  - gem update --system
 matrix:
   exclude:
     - gemfile: gemfiles/activesupport-6.0.gemfile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,10 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-  - 2.3.8
-  - 2.4.5
-  - 2.5.5
-  - 2.6.3
+  - 2.4.9
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
 gemfile:
   - Gemfile
   - gemfiles/activesupport-5.0.gemfile
@@ -16,6 +16,4 @@ before_script:
 matrix:
   exclude:
     - gemfile: gemfiles/activesupport-6.0.gemfile
-      rvm: 2.3.8
-    - gemfile: gemfiles/activesupport-6.0.gemfile
-      rvm: 2.4.5
+      rvm: 2.4.9


### PR DESCRIPTION
Replaces #129 

This removes an unnecessary gem step to fix a problem that is no longer a problem, but caused new problems.

Also supports just the mainline current ruby versions. https://www.ruby-lang.org/en/downloads/