### PR TITLE
[doc] Update information about the unitwise gem in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,12 +273,13 @@ Existing alternatives which were considered:
 
 ### Gem: [unitwise](https://github.com/joshwlewis/unitwise)
 * **Pros**
-  * Well written and maintained.
+  * Well written.
   * Conversions done with Unified Code for Units of Measure (UCUM) so highly accurate and reliable.
 * **Cons**
   * Lots of code. Good code, but lots of it.
   * Many modifications to core types.
   * ActiveRecord adapter exists but is written and maintained by a different person/org.
+  * Not actively maintained.
 
 ## Contributing
 


### PR DESCRIPTION
As of this commit, the last update was in 2017 (commit [f786d2e660721a0238949e7abce20852879de8ef](https://github.com/joshwlewis/unitwise/commit/f786d2e660721a0238949e7abce20852879de8ef), 3 years ago) so I don't think this gem should be considered actively maintained any longer.