### PR TITLE
Add structure to unit errors

### DIFF
--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -11,8 +11,18 @@ module Measured
     attr_reader :unit_name
 
     def initialize(unit_name)
-      @unit_name = unit_name
       super("Unit #{unit_name} has already been added.")
+      @unit_name = unit_name
+    end
+  end
+
+  class MissingConversionPath < UnitError
+    attr_reader :from, :to
+
+    def initialize(from, to)
+      super("Cannot find conversion path from #{from} to #{to}.")
+      @from = from
+      @to = to
     end
   end
 

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -6,26 +6,6 @@ require "bigdecimal"
 require "json"
 
 module Measured
-  class UnitError < StandardError ; end
-  class UnitAlreadyAdded < UnitError
-    attr_reader :unit_name
-
-    def initialize(unit_name)
-      super("Unit #{unit_name} has already been added.")
-      @unit_name = unit_name
-    end
-  end
-
-  class MissingConversionPath < UnitError
-    attr_reader :from, :to
-
-    def initialize(from, to)
-      super("Cannot find conversion path from #{from} to #{to}.")
-      @from = from
-      @to = to
-    end
-  end
-
   class << self
     def build(&block)
       builder = UnitSystemBuilder.new
@@ -57,6 +37,9 @@ module Measured
   end
 end
 
+require "measured/unit_error"
+require "measured/unit_already_added"
+require "measured/missing_conversion_path"
 require "measured/arithmetic"
 require "measured/parser"
 require "measured/unit"

--- a/lib/measured/base.rb
+++ b/lib/measured/base.rb
@@ -7,6 +7,14 @@ require "json"
 
 module Measured
   class UnitError < StandardError ; end
+  class UnitAlreadyAdded < UnitError
+    attr_reader :unit_name
+
+    def initialize(unit_name)
+      @unit_name = unit_name
+      super("Unit #{unit_name} has already been added.")
+    end
+  end
 
   class << self
     def build(&block)

--- a/lib/measured/conversion_table_builder.rb
+++ b/lib/measured/conversion_table_builder.rb
@@ -40,7 +40,7 @@ class Measured::ConversionTableBuilder
   def find_conversion(to:, from:)
     conversion = find_direct_conversion_cached(to: to, from: from) || find_tree_traversal_conversion(to: to, from: from)
 
-    raise Measured::UnitError, "Cannot find conversion path from #{ from } to #{ to }." unless conversion
+    raise Measured::MissingConversionPath.new(from, to) unless conversion
 
     conversion
   end

--- a/lib/measured/missing_conversion_path.rb
+++ b/lib/measured/missing_conversion_path.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured
   class MissingConversionPath < UnitError
     attr_reader :from, :to

--- a/lib/measured/missing_conversion_path.rb
+++ b/lib/measured/missing_conversion_path.rb
@@ -1,0 +1,11 @@
+module Measured
+  class MissingConversionPath < UnitError
+    attr_reader :from, :to
+
+    def initialize(from, to)
+      super("Cannot find conversion path from #{from} to #{to}.")
+      @from = from
+      @to = to
+    end
+  end
+end

--- a/lib/measured/unit_already_added.rb
+++ b/lib/measured/unit_already_added.rb
@@ -1,4 +1,4 @@
-
+# frozen_string_literal: true
 module Measured
   class UnitAlreadyAdded < UnitError
     attr_reader :unit_name

--- a/lib/measured/unit_already_added.rb
+++ b/lib/measured/unit_already_added.rb
@@ -1,0 +1,11 @@
+
+module Measured
+  class UnitAlreadyAdded < UnitError
+    attr_reader :unit_name
+
+    def initialize(unit_name)
+      super("Unit #{unit_name} has already been added.")
+      @unit_name = unit_name
+    end
+  end
+end

--- a/lib/measured/unit_error.rb
+++ b/lib/measured/unit_error.rb
@@ -1,0 +1,3 @@
+module Measured
+  class UnitError < StandardError ; end
+end

--- a/lib/measured/unit_error.rb
+++ b/lib/measured/unit_error.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Measured
   class UnitError < StandardError ; end
 end

--- a/lib/measured/unit_system_builder.rb
+++ b/lib/measured/unit_system_builder.rb
@@ -67,7 +67,7 @@ class Measured::UnitSystemBuilder
   def check_for_duplicate_unit_names!(unit)
     names = @units.flat_map(&:names)
     if names.any? { |name| unit.names.include?(name) }
-      raise Measured::UnitError, "Unit #{unit.name} has already been added."
+      raise Measured::UnitAlreadyAdded.new(unit.name)
     end
   end
 end

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -31,6 +31,19 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test "#unit raises when cannot find conversion path" do
+    error = assert_raises Measured::MissingConversionPath do
+      Measured.build do
+        unit :m
+        unit :in, value: "0.0254 m"
+        unit :pallets, value: "5 cases"
+      end
+    end
+    assert_equal("pallets", error.from)
+    assert_equal("m", error.to)
+    assert_equal("Cannot find conversion path from pallets to m.", error.message)
+  end
+
   test "#unit is case sensitive" do
     measurable = Measured.build do
       unit :normal

--- a/test/unit_system_builder_test.rb
+++ b/test/unit_system_builder_test.rb
@@ -12,15 +12,17 @@ class Measured::UnitSystemBuilderTest < ActiveSupport::TestCase
   end
 
   test "#unit cannot add duplicate unit names" do
-    assert_raises Measured::UnitError do
+    error = assert_raises Measured::UnitAlreadyAdded do
       Measured.build do
         unit :m
         unit :in, aliases: [:inch], value: "0.0254 m"
         unit :in, aliases: [:thing], value: "123 m"
       end
     end
+    assert_equal("in", error.unit_name)
+    assert_equal("Unit in has already been added.", error.message)
 
-    assert_raises Measured::UnitError do
+    assert_raises Measured::UnitAlreadyAdded do
       Measured.build do
         unit :m
         unit :in, aliases: [:inch], value: "0.0254 m"


### PR DESCRIPTION
This way, users of this library have more control on how to handle these errors, and provide their own custom error message.