### PR TITLE
Only support rails versions that are still supported, meaning 5.2 and above

### DIFF
--- a/measured.gemspec
+++ b/measured.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 5.0"
+  spec.add_runtime_dependency "activesupport", ">= 5.2"
 
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "minitest", "> 5.5.1"


### PR DESCRIPTION
Bumping version support to rails 5.2 because that's all that's supported officially.

https://guides.rubyonrails.org/maintenance_policy.html

Behaviour in old versions is undefined.

CI already matches this as of #134 