### PR TITLE
Release 2.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Unreleased
 -----
 
+2.8.0
+-----
+
+* Drop support for Ruby 2.5
+* Use Ruby 3.0.2 for development
+
 2.7.1
 -----
 

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Measured
-  VERSION = "2.7.1"
+  VERSION = "2.8.0"
 end


### PR DESCRIPTION
This is a tiny release:
https://github.com/Shopify/measured/compare/9047b7186e9168f0cbafaf80e34af4fbb881c2df...fd93dabe844f6a26272b9c7186ac63cbbc743141

It bumps dev ruby and drops support for ruby 2.5. I also renamed `master` to `main`.

Mostly it is to release https://github.com/Shopify/measured-rails/pull/67 and that gem is version locked to this one.