### PR TITLE
allow Measurable#format to drop the conversion string

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ Measured::Weight.new("3.14", "grams").format("%.1<value>f %<unit>s")
 
 If no string is passed to the `format` method it defaults to `"%.2<value>f %<unit>s"`.
 
+If the unit isn't the standard SI unit, it will include a conversion string.
+
+```ruby
+Measured::Weight.new("3.14", "kg").format
+> "3.14 kg (1000/1 g)"
+Measured::Weight.new("3.14", "kg").format(with_conversion_string: false)
+> "3.14 kg"
+```
+
 ## Units and conversions
 
 ### SI units support

--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -43,10 +43,10 @@ class Measured::Measurable < Numeric
     self.class.new(new_value, new_unit)
   end
 
-  def format(format_string=nil)
+  def format(format_string=nil, with_conversion_string: true)
     kwargs = {
       value: self.value,
-      unit: self.unit,
+      unit: self.unit.to_s(with_conversion_string: with_conversion_string),
     }
     (format_string || DEFAULT_FORMAT_STRING) % kwargs
   end

--- a/lib/measured/unit.rb
+++ b/lib/measured/unit.rb
@@ -23,8 +23,8 @@ class Measured::Unit
     )
   end
 
-  def to_s
-    if @conversion_string
+  def to_s(with_conversion_string: true)
+    if with_conversion_string && @conversion_string
       "#{name} (#{@conversion_string})".freeze
     else
       name

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -232,6 +232,11 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "9.34 magic_missile", Magic.new(9.342, :magic_missile).format
   end
 
+  test "#format can drop the conversion amount" do
+    assert_equal "1.00 fireball (2/3 magic_missile)", Magic.new(1, :fireball).format
+    assert_equal "1.00 fireball", Magic.new(1, :fireball).format(with_conversion_string: false)
+  end
+
   test "#humanize outputs the number and the unit properly pluralized" do
     assert_equal "1 fireball", Magic.new("1", :fire).humanize
     assert_equal "10 fireballs", Magic.new(10, :fire).humanize

--- a/test/unit_test.rb
+++ b/test/unit_test.rb
@@ -43,6 +43,10 @@ class Measured::UnitTest < ActiveSupport::TestCase
     assert_equal "pie (1/2 sweet)", Measured::Unit.new(:pie, aliases: ["cake"], value: "0.5 sweet").to_s
   end
 
+  test "#to_s can drop the conversion amount" do
+    assert_equal "pie", Measured::Unit.new(:pie).to_s(with_conversion_string: false)
+  end
+
   test "#inspect returns an expected string" do
     assert_equal "#<Measured::Unit: pie>", Measured::Unit.new(:pie).inspect
     assert_equal "#<Measured::Unit: pie (cake, semi-sweet)>", Measured::Unit.new(:pie, aliases: ["cake", "semi-sweet"]).inspect


### PR DESCRIPTION
Hi. #138 seemed like a reasonable request, so I tried to fulfill it.

I tried to follow existing conventions, but this is my first time looking at the repository, so I've probably missed something.