### PR TITLE
Coerce zero

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 -----
 
+* Add special case for zero coercion to allow direct use of `sum` method
+
 2.8.0
 -----
 

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -19,6 +19,8 @@ module Measured::Arithmetic
   def coerce(other)
     if other.is_a?(self.class)
       [other, self]
+    elsif other.is_a?(Numeric) && other.zero?
+      [self.class.new(other, self.unit), self]
     else
       raise TypeError, "Cannot coerce #{other.class} to #{self.class}"
     end

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -8,6 +8,10 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     @four = Magic.new(4, :magic_missile)
   end
 
+  test "should be able to sum same units" do
+    assert_equal Magic.new(9, :magic_missile), [@two, @three, @four].sum
+  end
+
   test "#+ should add together same units" do
     assert_equal Magic.new(5, :magic_missile), @two + @three
     assert_equal Magic.new(5, :magic_missile), @three + @two


### PR DESCRIPTION
### WHY

Ruby and Rails/ActiveSupports ```sum``` method  by default will seed the initial value with 0, this means we cannot conveniently sum measured enumerable values