### PR TITLE
Additional numeric helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 Unreleased
 -----
 
+* Add useful numeric methods `zero?`, `nonzero?`, `positive?` and `negative?`
+
 2.8.0
 -----
 

--- a/lib/measured/arithmetic.rb
+++ b/lib/measured/arithmetic.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 module Measured::Arithmetic
+  extend Forwardable
+  def_delegators :@value, :zero?, :positive?, :negative?
+
   def +(other)
     arithmetic_operation(other, :+)
   end
@@ -26,6 +29,10 @@ module Measured::Arithmetic
 
   def to_i
     raise TypeError, "#{self.class} cannot be converted to an integer"
+  end
+
+  def nonzero?
+    value.nonzero? ? self : false
   end
 
   private

--- a/test/arithmetic_test.rb
+++ b/test/arithmetic_test.rb
@@ -8,6 +8,26 @@ class Measured::ArithmeticTest < ActiveSupport::TestCase
     @four = Magic.new(4, :magic_missile)
   end
 
+  test 'can check for zero?' do
+    assert_equal true, Magic.new(0, :magic_missile).zero?
+    assert_equal false, Magic.new(1, :magic_missile).zero?
+  end
+
+  test 'can check for nonzero?' do
+    assert_equal Magic.new(10, :magic_missile), Magic.new(10, :magic_missile).nonzero?
+    assert_equal false, Magic.new(0, :magic_missile).nonzero?
+  end
+
+  test 'can check for positive?' do
+    assert_equal true, Magic.new(1, :magic_missile).positive?
+    assert_equal false, Magic.new(-1, :magic_missile).positive?
+  end
+
+  test 'can check for negative?' do
+    assert_equal true, Magic.new(-1, :magic_missile).negative?
+    assert_equal false, Magic.new(1, :magic_missile).negative?
+  end
+
   test "#+ should add together same units" do
     assert_equal Magic.new(5, :magic_missile), @two + @three
     assert_equal Magic.new(5, :magic_missile), @three + @two

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -246,12 +246,6 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal "#<Magic: 1.234 #<Measured::Unit: magic_missile (magic_missiles, magic missile)>>", Magic.new(1.234, :magic_missile).inspect
   end
 
-  test "#zero? always returns false" do
-    refute_predicate Magic.new(0, :fire), :zero?
-    refute_predicate Magic.new(0.0, :fire), :zero?
-    refute_predicate Magic.new("0.0", :fire), :zero?
-  end
-
   test "#<=> compares regardless of the unit" do
     assert_equal (-1), @magic <=> Magic.new(20, :fire)
     assert_equal 1, @magic <=> Magic.new(9, :magic_missile)


### PR DESCRIPTION
WHY

Add useful numeric methods zero?, nonzero?, positive? and negative?

Looks like this functionality was removed way back in PR #49 it seems to be the reasoning was around auto-coercion of numeric into measured units caused confusion, I don't believe this PR reintroduces this issue.