### PR TITLE
Add mm3 cm3 volume unit conversion

### DIFF
--- a/cache/volume.json
+++ b/cache/volume.json
@@ -89,6 +89,14 @@
       "numerator": 1,
       "denominator": 1000
     },
+    "cm3": {
+      "numerator": 1000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000000,
       "denominator": 2048383
@@ -218,6 +226,14 @@
     "m3": {
       "numerator": 1,
       "denominator": 1000000000000000000000000000
+    },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1000000000000000000
     },
     "in3": {
       "numerator": 1,
@@ -349,6 +365,14 @@
       "numerator": 1,
       "denominator": 1000000000000000000000000
     },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000000000000000000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1000000000000000
+    },
     "in3": {
       "numerator": 1,
       "denominator": 16387064000000000000
@@ -478,6 +502,14 @@
     "m3": {
       "numerator": 1,
       "denominator": 1000000000000000000000
+    },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000000000000000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1000000000000
     },
     "in3": {
       "numerator": 1,
@@ -609,6 +641,14 @@
       "numerator": 1,
       "denominator": 1000000000000000000
     },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000000000000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1000000000
+    },
     "in3": {
       "numerator": 1,
       "denominator": 16387064000000
@@ -738,6 +778,14 @@
     "m3": {
       "numerator": 1,
       "denominator": 1000000000000000
+    },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000000000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1000000
     },
     "in3": {
       "numerator": 1,
@@ -869,6 +917,14 @@
       "numerator": 1,
       "denominator": 1000000000000
     },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1000
+    },
     "in3": {
       "numerator": 1,
       "denominator": 16387064
@@ -998,6 +1054,14 @@
     "m3": {
       "numerator": 1,
       "denominator": 1000000000
+    },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000
+    },
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1
     },
     "in3": {
       "numerator": 125,
@@ -1129,6 +1193,14 @@
       "numerator": 1,
       "denominator": 1000000
     },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000,
       "denominator": 2048383
@@ -1258,6 +1330,14 @@
     "m3": {
       "numerator": 1,
       "denominator": 100000
+    },
+    "cm3": {
+      "numerator": 10,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 10000,
+      "denominator": 1
     },
     "in3": {
       "numerator": 1250000,
@@ -1389,6 +1469,14 @@
       "numerator": 1,
       "denominator": 10000
     },
+    "cm3": {
+      "numerator": 100,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 100000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 12500000,
       "denominator": 2048383
@@ -1518,6 +1606,14 @@
     "m3": {
       "numerator": 1,
       "denominator": 100
+    },
+    "cm3": {
+      "numerator": 10000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 10000000,
+      "denominator": 1
     },
     "in3": {
       "numerator": 1250000000,
@@ -1649,6 +1745,14 @@
       "numerator": 1,
       "denominator": 10
     },
+    "cm3": {
+      "numerator": 100000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 100000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 12500000000,
       "denominator": 2048383
@@ -1777,6 +1881,14 @@
     },
     "m3": {
       "numerator": 1,
+      "denominator": 1
+    },
+    "cm3": {
+      "numerator": 1000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000,
       "denominator": 1
     },
     "in3": {
@@ -1909,6 +2021,14 @@
       "numerator": 1000,
       "denominator": 1
     },
+    "cm3": {
+      "numerator": 1000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000000000000,
       "denominator": 2048383
@@ -2037,6 +2157,14 @@
     },
     "m3": {
       "numerator": 1000000,
+      "denominator": 1
+    },
+    "cm3": {
+      "numerator": 1000000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000000,
       "denominator": 1
     },
     "in3": {
@@ -2169,6 +2297,14 @@
       "numerator": 1000000000,
       "denominator": 1
     },
+    "cm3": {
+      "numerator": 1000000000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000000000000000000,
       "denominator": 2048383
@@ -2297,6 +2433,14 @@
     },
     "m3": {
       "numerator": 1000000000000,
+      "denominator": 1
+    },
+    "cm3": {
+      "numerator": 1000000000000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000000000000,
       "denominator": 1
     },
     "in3": {
@@ -2429,6 +2573,14 @@
       "numerator": 1000000000000000,
       "denominator": 1
     },
+    "cm3": {
+      "numerator": 1000000000000000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000000000000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000000000000000000000000,
       "denominator": 2048383
@@ -2557,6 +2709,14 @@
     },
     "m3": {
       "numerator": 1000000000000000000,
+      "denominator": 1
+    },
+    "cm3": {
+      "numerator": 1000000000000000000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000000000000000000,
       "denominator": 1
     },
     "in3": {
@@ -2689,6 +2849,14 @@
       "numerator": 1000000000000000000000,
       "denominator": 1
     },
+    "cm3": {
+      "numerator": 1000000000000000000000000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000000000000000000000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000000000000000000000000000000,
       "denominator": 2048383
@@ -2819,6 +2987,14 @@
       "numerator": 1,
       "denominator": 1000000000000000000000
     },
+    "cm3": {
+      "numerator": 1000000,
+      "denominator": 1
+    },
+    "mm3": {
+      "numerator": 1000000000,
+      "denominator": 1
+    },
     "in3": {
       "numerator": 125000000000,
       "denominator": 2048383
@@ -2857,6 +3033,282 @@
     },
     "us_oz": {
       "numerator": 16000000000000,
+      "denominator": 473176473
+    }
+  },
+  "cm3": {
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1
+    },
+    "l": {
+      "numerator": 1,
+      "denominator": 1000
+    },
+    "yl": {
+      "numerator": 1000000000000000000000,
+      "denominator": 1
+    },
+    "zl": {
+      "numerator": 1000000000000000000,
+      "denominator": 1
+    },
+    "al": {
+      "numerator": 1000000000000000,
+      "denominator": 1
+    },
+    "fl": {
+      "numerator": 1000000000000,
+      "denominator": 1
+    },
+    "pl": {
+      "numerator": 1000000000,
+      "denominator": 1
+    },
+    "nl": {
+      "numerator": 1000000,
+      "denominator": 1
+    },
+    "μl": {
+      "numerator": 1000,
+      "denominator": 1
+    },
+    "ml": {
+      "numerator": 1,
+      "denominator": 1
+    },
+    "cl": {
+      "numerator": 1,
+      "denominator": 10
+    },
+    "dl": {
+      "numerator": 1,
+      "denominator": 100
+    },
+    "dal": {
+      "numerator": 1,
+      "denominator": 10000
+    },
+    "hl": {
+      "numerator": 1,
+      "denominator": 100000
+    },
+    "kl": {
+      "numerator": 1,
+      "denominator": 1000000
+    },
+    "Ml": {
+      "numerator": 1,
+      "denominator": 1000000000
+    },
+    "Gl": {
+      "numerator": 1,
+      "denominator": 1000000000000
+    },
+    "Tl": {
+      "numerator": 1,
+      "denominator": 1000000000000000
+    },
+    "Pl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000
+    },
+    "El": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000
+    },
+    "Zl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000000
+    },
+    "Yl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000000000
+    },
+    "m3": {
+      "numerator": 1,
+      "denominator": 1000000
+    },
+    "mm3": {
+      "numerator": 1000,
+      "denominator": 1
+    },
+    "in3": {
+      "numerator": 125000,
+      "denominator": 2048383
+    },
+    "ft3": {
+      "numerator": 15625,
+      "denominator": 442450728
+    },
+    "gal": {
+      "numerator": 100,
+      "denominator": 454609
+    },
+    "us_gal": {
+      "numerator": 125000,
+      "denominator": 473176473
+    },
+    "qt": {
+      "numerator": 400,
+      "denominator": 454609
+    },
+    "us_qt": {
+      "numerator": 500000,
+      "denominator": 473176473
+    },
+    "pt": {
+      "numerator": 800,
+      "denominator": 454609
+    },
+    "us_pt": {
+      "numerator": 1000000,
+      "denominator": 473176473
+    },
+    "oz": {
+      "numerator": 16000,
+      "denominator": 454609
+    },
+    "us_oz": {
+      "numerator": 16000000,
+      "denominator": 473176473
+    }
+  },
+  "mm3": {
+    "mm3": {
+      "numerator": 1,
+      "denominator": 1
+    },
+    "l": {
+      "numerator": 1,
+      "denominator": 1000000
+    },
+    "yl": {
+      "numerator": 1000000000000000000,
+      "denominator": 1
+    },
+    "zl": {
+      "numerator": 1000000000000000,
+      "denominator": 1
+    },
+    "al": {
+      "numerator": 1000000000000,
+      "denominator": 1
+    },
+    "fl": {
+      "numerator": 1000000000,
+      "denominator": 1
+    },
+    "pl": {
+      "numerator": 1000000,
+      "denominator": 1
+    },
+    "nl": {
+      "numerator": 1000,
+      "denominator": 1
+    },
+    "μl": {
+      "numerator": 1,
+      "denominator": 1
+    },
+    "ml": {
+      "numerator": 1,
+      "denominator": 1000
+    },
+    "cl": {
+      "numerator": 1,
+      "denominator": 10000
+    },
+    "dl": {
+      "numerator": 1,
+      "denominator": 100000
+    },
+    "dal": {
+      "numerator": 1,
+      "denominator": 10000000
+    },
+    "hl": {
+      "numerator": 1,
+      "denominator": 100000000
+    },
+    "kl": {
+      "numerator": 1,
+      "denominator": 1000000000
+    },
+    "Ml": {
+      "numerator": 1,
+      "denominator": 1000000000000
+    },
+    "Gl": {
+      "numerator": 1,
+      "denominator": 1000000000000000
+    },
+    "Tl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000
+    },
+    "Pl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000
+    },
+    "El": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000000
+    },
+    "Zl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000000000
+    },
+    "Yl": {
+      "numerator": 1,
+      "denominator": 1000000000000000000000000000000
+    },
+    "m3": {
+      "numerator": 1,
+      "denominator": 1000000000
+    },
+    "cm3": {
+      "numerator": 1,
+      "denominator": 1000
+    },
+    "in3": {
+      "numerator": 125,
+      "denominator": 2048383
+    },
+    "ft3": {
+      "numerator": 125,
+      "denominator": 3539605824
+    },
+    "gal": {
+      "numerator": 1,
+      "denominator": 4546090
+    },
+    "us_gal": {
+      "numerator": 125,
+      "denominator": 473176473
+    },
+    "qt": {
+      "numerator": 2,
+      "denominator": 2273045
+    },
+    "us_qt": {
+      "numerator": 500,
+      "denominator": 473176473
+    },
+    "pt": {
+      "numerator": 4,
+      "denominator": 2273045
+    },
+    "us_pt": {
+      "numerator": 1000,
+      "denominator": 473176473
+    },
+    "oz": {
+      "numerator": 16,
+      "denominator": 454609
+    },
+    "us_oz": {
+      "numerator": 16000,
       "denominator": 473176473
     }
   },
@@ -2952,6 +3404,14 @@
     "m3": {
       "numerator": 2048383,
       "denominator": 125000000000
+    },
+    "cm3": {
+      "numerator": 2048383,
+      "denominator": 125000
+    },
+    "mm3": {
+      "numerator": 2048383,
+      "denominator": 125
     },
     "ft3": {
       "numerator": 1,
@@ -3083,6 +3543,14 @@
       "numerator": 55306341,
       "denominator": 1953125000
     },
+    "cm3": {
+      "numerator": 442450728,
+      "denominator": 15625
+    },
+    "mm3": {
+      "numerator": 3539605824,
+      "denominator": 125
+    },
     "in3": {
       "numerator": 1728,
       "denominator": 1
@@ -3212,6 +3680,14 @@
     "m3": {
       "numerator": 454609,
       "denominator": 100000000
+    },
+    "cm3": {
+      "numerator": 454609,
+      "denominator": 100
+    },
+    "mm3": {
+      "numerator": 4546090,
+      "denominator": 1
     },
     "in3": {
       "numerator": 568261250,
@@ -3343,6 +3819,14 @@
       "numerator": 473176473,
       "denominator": 125000000000
     },
+    "cm3": {
+      "numerator": 473176473,
+      "denominator": 125000
+    },
+    "mm3": {
+      "numerator": 473176473,
+      "denominator": 125
+    },
     "in3": {
       "numerator": 231,
       "denominator": 1
@@ -3472,6 +3956,14 @@
     "m3": {
       "numerator": 454609,
       "denominator": 400000000
+    },
+    "cm3": {
+      "numerator": 454609,
+      "denominator": 400
+    },
+    "mm3": {
+      "numerator": 2273045,
+      "denominator": 2
     },
     "in3": {
       "numerator": 284130625,
@@ -3603,6 +4095,14 @@
       "numerator": 473176473,
       "denominator": 500000000000
     },
+    "cm3": {
+      "numerator": 473176473,
+      "denominator": 500000
+    },
+    "mm3": {
+      "numerator": 473176473,
+      "denominator": 500
+    },
     "in3": {
       "numerator": 231,
       "denominator": 4
@@ -3732,6 +4232,14 @@
     "m3": {
       "numerator": 454609,
       "denominator": 800000000
+    },
+    "cm3": {
+      "numerator": 454609,
+      "denominator": 800
+    },
+    "mm3": {
+      "numerator": 2273045,
+      "denominator": 4
     },
     "in3": {
       "numerator": 284130625,
@@ -3863,6 +4371,14 @@
       "numerator": 473176473,
       "denominator": 1000000000000
     },
+    "cm3": {
+      "numerator": 473176473,
+      "denominator": 1000000
+    },
+    "mm3": {
+      "numerator": 473176473,
+      "denominator": 1000
+    },
     "in3": {
       "numerator": 231,
       "denominator": 8
@@ -3993,6 +4509,14 @@
       "numerator": 454609,
       "denominator": 16000000000
     },
+    "cm3": {
+      "numerator": 454609,
+      "denominator": 16000
+    },
+    "mm3": {
+      "numerator": 454609,
+      "denominator": 16
+    },
     "in3": {
       "numerator": 56826125,
       "denominator": 32774128
@@ -4122,6 +4646,14 @@
     "m3": {
       "numerator": 473176473,
       "denominator": 16000000000000
+    },
+    "cm3": {
+      "numerator": 473176473,
+      "denominator": 16000000
+    },
+    "mm3": {
+      "numerator": 473176473,
+      "denominator": 16000
     },
     "in3": {
       "numerator": 231,

--- a/lib/measured/units/volume.rb
+++ b/lib/measured/units/volume.rb
@@ -3,6 +3,8 @@ Measured::Volume = Measured.build do
   si_unit :l, aliases: [:liter, :litre, :liters, :litres]
 
   unit :m3, value: "1000 l", aliases: [:cubic_meter, :cubic_metre, :cubic_meters, :cubic_metres]
+  unit :cm3, value: "0.001 l", aliases: [:cubic_centimeter, :cubic_centimetre, :cubic_centimeters, :cubic_centimetres]
+  unit :mm3, value: "0.000001 l", aliases: [:cubic_millimeter, :cubic_millimetre, :cubic_millimeters, :cubic_millimetres]
   unit :in3, value: "0.016387064 l", aliases: [:cubic_inch, :cubic_inches]
   unit :ft3, value: "1728 in3", aliases: [:cubic_foot, :cubic_feet]
   unit :gal, value: "4.54609 l", aliases: [:imp_gal, :imperial_gallon, :imp_gals, :imperial_gallons]

--- a/test/units/volume_test.rb
+++ b/test/units/volume_test.rb
@@ -19,6 +19,16 @@ class Measured::VolumeTest < ActiveSupport::TestCase
       liters
       litres
       ft3
+      cm3
+      cubic_centimeter
+      cubic_centimeters
+      cubic_centimetre
+      cubic_centimetres
+      mm3
+      cubic_millimeter
+      cubic_millimeters
+      cubic_millimetre
+      cubic_millimetres
       cubic_foot
       cubic_feet
       in3
@@ -67,7 +77,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
   end
 
   test ".unit_names should be the list of base unit names" do
-    expected_units = %w(l m3 ft3 in3 gal us_gal qt us_qt pt us_pt oz us_oz)
+    expected_units = %w(l m3 ft3 in3 gal us_gal qt us_qt pt us_pt oz us_oz mm3 cm3)
     expected_units += Measured::UnitSystemBuilder::SI_PREFIXES.map { |short, _, _| "#{short}l" }
     assert_equal expected_units.sort, Measured::Volume.unit_names
   end
@@ -123,6 +133,102 @@ class Measured::VolumeTest < ActiveSupport::TestCase
 
   test ".convert_to from us_oz to us_oz" do
     assert_conversion Measured::Volume, "2000 us_oz", "2000 us_oz"
+  end
+  
+  test ".convert_to from mm3 to mm3" do
+    assert_conversion Measured::Volume, "20000 mm3", "20000 mm3"
+  end
+
+  test ".convert_to from cm3 to cm3" do
+    assert_conversion Measured::Volume, "20000 cm3", "20000 cm3"
+  end
+
+  test ".convert_to from mm3 to m3" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.00002 m3"
+  end
+
+  test ".convert_to from mm3 to ft3" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.00070629333 ft3"
+  end
+
+  test ".convert_to from mm3 to in3" do
+    assert_conversion Measured::Volume, "20000 mm3", "1.2204749 in3"
+  end
+
+  test ".convert_to from mm3 to gal" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.004399384965981756 gal"
+  end
+
+  test ".convert_to from mm3 to us_gal" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.005283441047162969 us_gal"
+  end
+
+  test ".convert_to from mm3 to qt" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.01759754 qt"
+  end
+
+  test ".convert_to from mm3 to us_qt" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.021133764 us_qt"
+  end
+
+  test ".convert_to from mm3 to pt" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.03519508 pt"
+  end
+
+  test ".convert_to from mm3 to us_pt" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.042267528 us_pt"
+  end
+
+  test ".convert_to from mm3 to oz" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.70390159 oz"
+  end
+
+  test ".convert_to from mm3 to us_oz" do
+    assert_conversion Measured::Volume, "20000 mm3", "0.67628045 us_oz"
+  end
+
+  test ".convert_to from cm3 to m3" do
+    assert_conversion Measured::Volume, "20000 cm3", "0.02 m3"
+  end
+
+  test ".convert_to from cm3 to ft3" do
+    assert_conversion Measured::Volume, "20000 cm3", "0.70629333 ft3"
+  end
+
+  test ".convert_to from cm3 to in3" do
+    assert_conversion Measured::Volume, "20000 cm3", "1220.4748818946457 in3"
+  end
+
+  test ".convert_to from cm3 to gal" do
+    assert_conversion Measured::Volume, "20000 cm3", "4.399384965981756 gal"
+  end
+
+  test ".convert_to from cm3 to us_gal" do
+    assert_conversion Measured::Volume, "20000 cm3", "5.283441047162969 us_gal"
+  end
+
+  test ".convert_to from cm3 to qt" do
+    assert_conversion Measured::Volume, "20000 cm3", "17.59754 qt"
+  end
+
+  test ".convert_to from cm3 to us_qt" do
+    assert_conversion Measured::Volume, "20000 cm3", "21.133764 us_qt"
+  end
+
+  test ".convert_to from cm3 to pt" do
+    assert_conversion Measured::Volume, "20000 cm3", "35.19508 pt"
+  end
+
+  test ".convert_to from cm3 to us_pt" do
+    assert_conversion Measured::Volume, "20000 cm3", "42.267528 us_pt"
+  end
+
+  test ".convert_to from cm3 to oz" do
+    assert_conversion Measured::Volume, "20000 cm3", "703.9015945570809 oz"
+  end
+
+  test ".convert_to from cm3 to us_oz" do
+    assert_conversion Measured::Volume, "20000 cm3", "676.28045403686 us_oz"
   end
 
   test ".convert_to from ml to m3" do


### PR DESCRIPTION
Add support additional volume units:

- Cubic centimeter `cm3` - 1 cubic centimeter = 0.001 liters
- Cubic millimeter `mm3` - 1 cubic millimeter = 0.000001 liters

Native support for `cm3` and `mm3` units in the measured gem.

Added:
Unit conversion
Tests for all unit conversions
Updated cache



