### PR TITLE
On initialize, convert strings to rational if they follow rational pattern

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -17,6 +17,8 @@ class Measured::Measurable < Numeric
       value
     when Integer
       Rational(value)
+    when String
+      /\d+\/\d+/.match?(value) ? Rational(value) : BigDecimal(value)
     else
       BigDecimal(value)
     end

--- a/test/measurable_test.rb
+++ b/test/measurable_test.rb
@@ -41,6 +41,10 @@ class Measured::MeasurableTest < ActiveSupport::TestCase
     assert_equal BigDecimal("9.1234572342342"), Magic.new("9.1234572342342", :fire).value
   end
 
+  test "#initialize converts strings to Rational if they follow Rational pattern" do
+    assert_equal Rational(1, 3), Magic.new("1/3", :fire).value
+  end
+
   test "#initialize converts to the base unit" do
     assert_equal @fireball, Magic.new(1, :fire).unit
   end


### PR DESCRIPTION
Adds support to initialize `Measured` object with a rational value from string (currently raises): 
```ruby
Measured::Weight.new("1/3", :g).value
#=> (1/3)
```

Fixes https://github.com/Shopify/measured/issues/148

Question: how can this be further tested? 