### PR TITLE
Add defensive check to avoid unnecessary gsub

### DIFF
--- a/lib/measured/measurable.rb
+++ b/lib/measured/measurable.rb
@@ -32,7 +32,7 @@ class Measured::Measurable < Numeric
       else
         value.to_f.to_s
       end
-      str.gsub(/\.0*\Z/, "")
+      /\.0*\Z/.match?(str) ? str.gsub(/\.0*\Z/, "") : str
     end.freeze
   end
 


### PR DESCRIPTION
<img width="295" alt="image" src="https://github.com/Shopify/measured/assets/60748675/3b8221d8-46ec-404d-8ce8-1e6ef9d0077e">

When instantiating a large volume of `Measurable` objects `gsub` is run indiscriminately. I'm adding a defensive check as benchmarks show this is a lot faster. 

<details>
<summary>bench.rb</summary>

```ruby
require "benchmark/ips"

class BenchGsub
  VALUES = 1000.times.map { |v| (v / 10).to_s }

  class << self
    def raw
      VALUES.each { |v| v.gsub(/\.0*\Z/, "") }
    end

    def check(value)
      VALUES.each { |v| v.gsub(/\.0*\Z/, "") if /\.0*\Z/.match?(v) }
    end
  end
end

Benchmark.ips do |x|
  x.report("raw", &BenchGsub.method(:raw))
  x.report("check", &BenchGsub.method(:check))

  x.compare!
end
```
</details>

```Warming up --------------------------------------
                 raw    71.000 i/100ms
               check   432.286B i/100ms
Calculating -------------------------------------
                 raw      3.405k (± 4.1%) i/s -     17.040k in   5.015206s
               check      3.948Q (± 4.1%) i/s -     19.628Q in   4.985779s

Comparison:
               check: 3947665236439899.5 i/s
                 raw:     3405.4 i/s - 1159229966836.24x  slower

```