### PR TITLE
Configure dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+registries:
+  ruby-shopify:
+    type: rubygems-server
+    url: https://pkgs.shopify.io/basic/gems/ruby
+    username: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_USERNAME}}
+    password: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_PASSWORD}}
+  github-com:
+    type: git
+    url: https://github.com
+    username: ${{secrets.DEPENDENCIES_GITHUB_USER}}
+    password: ${{secrets.DEPENDENCIES_GITHUB_TOKEN}}
+updates:
+  - package-ecosystem: bundler
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 100
+    insecure-external-code-execution: allow
+    registries: "*"


### PR DESCRIPTION
Fixes https://github.com/Shopify/services/issues/6240

`measured` doesn't have Dependabot set up. This PR adds the configuration for dependabot

I basically just copied the `.github/dependabot.yml` in the ticket (but set `schedule interval` to `weekly` instead of `daily`)

```
version: 2
registries:
  ruby-shopify:
    type: rubygems-server
    url: https://pkgs.shopify.io/basic/gems/ruby
    username: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_USERNAME}}
    password: ${{secrets.RUBYGEMS_SERVER_PKGS_SHOPIFY_IO_PASSWORD}}
  github-com:
    type: git
    url: https://github.com
    username: ${{secrets.DEPENDENCIES_GITHUB_USER}}
    password: ${{secrets.DEPENDENCIES_GITHUB_TOKEN}}
updates:
  - package-ecosystem: bundler
    directory: "/"
    schedule:
      interval: daily      // I changed this to weekly
    open-pull-requests-limit: 100
    insecure-external-code-execution: allow
    registries: "*"
```