### PR TITLE
Update Ruby and Rails versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,18 +10,18 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.0'
           - '3.1'
           - '3.2'
+          - '3.3'
         gemfile:
           - Gemfile
-          - gemfiles/rails-6.0.gemfile
-          - gemfiles/rails-6.1.gemfile
           - gemfiles/rails-7.0.gemfile
+          - gemfiles/rails-7.1.gemfile
           - gemfiles/rails-edge.gemfile
         exclude:
-          # Rails Edge only supports Ruby >= 3.1
-          - ruby: '3.0'
+          - ruby: '3.1'
+            gemfile: gemfiles/rails-edge.gemfile
+          - ruby: '3.2'
             gemfile: gemfiles/rails-edge.gemfile
 
     name: Ruby ${{ matrix.ruby }} ${{ matrix.gemfile }}

--- a/gemfiles/rails-6.0.gemfile
+++ b/gemfiles/rails-6.0.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 6.0'
-gem "activerecord", '~> 6.0'

--- a/gemfiles/rails-6.1.gemfile
+++ b/gemfiles/rails-6.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 6.1'
-gem "activerecord", '~> 6.1'

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 7.1'
+gem "activerecord", '~> 7.1'

--- a/measured.gemspec
+++ b/measured.gemspec
@@ -36,6 +36,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "mocha", ">= 1.4.0"
   spec.add_development_dependency "pry"
   spec.add_development_dependency "combustion"
-  spec.add_development_dependency "sqlite3", "~> 1.4"
+  spec.add_development_dependency "sqlite3", "> 1.4"
   spec.add_development_dependency "tapioca"
 end


### PR DESCRIPTION
I'm trying to merge https://github.com/Shopify/measured/pull/159 but CI is failing because the Ruby and Rails versions are all out of date.

I dropped some older rails and ruby, and added 3.3. Since edge is now rails 8, that will need ruby 3.3.

I'll do a version bump after this and the other PR.

cc @ragarwal6397