### PR TITLE
Bump version to 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@ Unreleased
 -----
 
 
+3.1.0
+-----
+* Drop support for Rails 6 and Ruby 3.0.
+* Add qunitals. Add aliases for UK ton/tonne. (@ragarwal6397)
+
 
 3.0.0
 -----

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Measured
-  VERSION = "3.0.0"
+  VERSION = "3.1.0"
 end


### PR DESCRIPTION
Includes:
* https://github.com/Shopify/measured/pull/159
* https://github.com/Shopify/measured/pull/160