### PR TITLE
[Intl] Add alias for `floz` to existing fluid ounces definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Unreleased
 -----
 
+3.2.1
+-----
+* Add an alias for `floz` to fluid ounces. (@h4sohail)
+
 3.2.0
 -----
 * Make the ActiveRecord validation errors have the correct type. (@alexcarruthers)

--- a/lib/measured/units/volume.rb
+++ b/lib/measured/units/volume.rb
@@ -13,7 +13,7 @@ Measured::Volume = Measured.build do
   unit :us_qt, value: "0.25 us_gal", aliases: [:us_quart, :us_quarts]
   unit :pt, value: "0.125 gal", aliases: [:imp_pt, :imperial_pint, :imp_pts, :imperial_pints]
   unit :us_pt, value: "0.125 us_gal", aliases: [:us_pint, :us_pints]
-  unit :oz, value: "0.00625 gal", aliases: [:fl_oz, :imp_fl_oz, :imperial_fluid_ounce, :imperial_fluid_ounces]
+  unit :oz, value: "0.00625 gal", aliases: [:floz, :fl_oz, :imp_fl_oz, :imperial_fluid_ounce, :imperial_fluid_ounces]
   unit :us_oz, value: "0.0078125 us_gal", aliases: [:us_fl_oz, :us_fluid_ounce, :us_fluid_ounces]
 
   cache Measured::Cache::Json, "volume.json"

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Measured
-  VERSION = "3.2.0"
+  VERSION = "3.2.1"
 end

--- a/test/units/volume_test.rb
+++ b/test/units/volume_test.rb
@@ -60,6 +60,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
       us_pint
       us_pints
       oz
+      floz
       fl_oz
       imp_fl_oz
       imperial_fluid_ounce
@@ -134,7 +135,7 @@ class Measured::VolumeTest < ActiveSupport::TestCase
   test ".convert_to from us_oz to us_oz" do
     assert_conversion Measured::Volume, "2000 us_oz", "2000 us_oz"
   end
-  
+
   test ".convert_to from mm3 to mm3" do
     assert_conversion Measured::Volume, "20000 mm3", "20000 mm3"
   end


### PR DESCRIPTION
We're adding imperial unit support for products and pricing and we noticed `floz` was missing as an alias for fluid ounces and are hence updating the gem to include support for `floz`. 