### PR TITLE
Update CI matrix and bump version to 3.3.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,12 @@ jobs:
         ruby:
           - '3.2'
           - '3.3'
+          - '3.4'
+          - '4.0'
         gemfile:
           - Gemfile
-          - gemfiles/rails-7.0.gemfile
-          - gemfiles/rails-7.1.gemfile
+          - gemfiles/rails-7.2.gemfile
+          - gemfiles/rails-8.0.gemfile
           - gemfiles/rails-edge.gemfile
         exclude:
           - ruby: '3.2'
@@ -23,9 +25,9 @@ jobs:
 
     name: Ruby ${{ matrix.ruby }} ${{ matrix.gemfile }}
     steps:
-      - uses: actions/checkout@50fbc622fc4ef5163becd7fab6573eac35f8462e # v1.2.0
+      - uses: actions/checkout@v4
       - name: Set up Ruby ${{ matrix.ruby }}
-        uses: ruby/setup-ruby@e34163cd15f4bb403dcd72d98e295997e6a55798 # v1.238.0
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true

--- a/gemfiles/rails-7.0.gemfile
+++ b/gemfiles/rails-7.0.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 7.0'
-gem 'activerecord', '~> 7.0'

--- a/gemfiles/rails-7.1.gemfile
+++ b/gemfiles/rails-7.1.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-
-gemspec path: '..'
-
-gem 'activesupport', '~> 7.1'
-gem "activerecord", '~> 7.1'

--- a/gemfiles/rails-7.2.gemfile
+++ b/gemfiles/rails-7.2.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 7.2'
+gem 'activerecord', '~> 7.2'

--- a/gemfiles/rails-8.0.gemfile
+++ b/gemfiles/rails-8.0.gemfile
@@ -1,0 +1,6 @@
+source 'https://rubygems.org'
+
+gemspec path: '..'
+
+gem 'activesupport', '~> 8.0'
+gem 'activerecord', '~> 8.0'

--- a/lib/measured/version.rb
+++ b/lib/measured/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Measured
-  VERSION = "3.2.1"
+  VERSION = "3.3.0"
 end

--- a/measured.gemspec
+++ b/measured.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/Shopify/measured"
   spec.license       = "MIT"
 
-  spec.required_ruby_version = ">= 3.0.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   # Prevent pushing this gem to RubyGems.org by setting 'allowed_push_host', or
   # delete this section to allow pushing this gem to any host.
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activesupport", ">= 5.2"
+  spec.add_runtime_dependency "activesupport", ">= 7.2"
 
   spec.add_development_dependency "rake", "> 10.0"
   spec.add_development_dependency "minitest", "> 5.5.1"


### PR DESCRIPTION
## Summary

Updates the CI matrix and dependency requirements to currently supported versions, and bumps the gem version to 3.3.0.

### CI matrix

**Ruby:**
- Add 3.4
- Keep 3.2, 3.3
- Drop 3.1 (EOL March 2025)

**Rails:**
- Add 7.2, 8.0
- Keep edge
- Drop 7.0 (EOL April 2025), 7.1 (EOL October 2025)

### GitHub Actions

- `actions/checkout`: pinned SHA (v1.2.0) to `@v4`
- `ruby/setup-ruby`: pinned SHA (v1.238.0) to `@v1`

### Dependency requirements

- `required_ruby_version`: `>= 3.0.0` to `>= 3.2.0`
- `activesupport`: `>= 5.2` to `>= 7.2`
- `tapioca`: `>= 0.17.0` (already set by #187)

### Version bump

3.2.1 to 3.3.0 (minor bump for the dependency floor changes).